### PR TITLE
Fix: LLVM Absolute Path build issues on MacOS

### DIFF
--- a/compiler+runtime/CMakeLists.txt
+++ b/compiler+runtime/CMakeLists.txt
@@ -180,7 +180,8 @@ endfunction()
 # can configure jank correctly during the build phase and then it'll just
 # continue to work with that setup once it's installed.
 execute_process(
-  COMMAND bash -c "${CMAKE_CXX_COMPILER} -xc++ -E -v /dev/null 2>&1 | sed -n -e '/^.include/,\${' -e '/^ \\/.*/p' -e '}' | sed 's/^[[:space:]]\\{1,\\}/-I/' | sed 's/ (framework directory)//'"  RESULT_VARIABLE clang_system_includes_result
+  COMMAND bash -c "${CMAKE_CXX_COMPILER} -xc++ -E -v /dev/null 2>&1 | sed -n -e '/^.include/,\${' -e '/^ \\/.*/p' -e '}' | sed 's/^[[:space:]]\\{1,\\}/-I/' | sed 's/ (framework directory)//'"
+  RESULT_VARIABLE clang_system_includes_result
   OUTPUT_VARIABLE clang_system_includes_unescaped
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )


### PR DESCRIPTION
All credit to Michael Bradley on the Clojurian Slack for this fix.
Just making this PR to resolve the issue that MacOS users are having.

I tested on my Linux build that the change to the executing bash command did not break it, but have not personally tested on MacOS. Tested by others on the Clojurian Slack.