### PR TITLE
Add missing actions/checkout in build-clang job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,9 @@ jobs:
           path: |
             ${{ github.workspace }}/compiler+runtime/build/llvm-install
           key: ${{ runner.os }}-${{ hashFiles('${{ github.workspace }}/compiler+runtime/bin/build-clang') }}
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
       - name: Build Clang/LLVM
         run: |
           if [[ ! -e ${{ github.workspace }}/compiler+runtime/build/llvm-install/usr/local/bin/clang++ ]];


### PR DESCRIPTION
When no cache is present, e.g. in initial GHA runs of a fork, the build-clang job would fail because an expected path does not exist. Cloning the repo before the "Build Clang/LLVM" step fixes that problem; it is not necessary for this purpose to checkout submodules.