### PR TITLE
Publish to a VPS PPA now

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,7 +162,7 @@ jobs:
           ssh -i "${JANK_SSH_KEY}" root@ppa.jank-lang.org "~/update+sign"
 
   build-nix:
-    name: "nix - release"
+    name: "Nix - release"
     runs-on: ubuntu-latest
     steps:
     - name: "Set up nix"


### PR DESCRIPTION
We ran _very quickly_ into Github LFS bandwidth limits. We have 10GB per
month but we hit it in 10 days. I've set up a VPS just for hosting these
files and we can put a CDN in front of that, if needed.