### PR TITLE
Fix `contains?` for `nil` in `array_map`

### DIFF
--- a/compiler+runtime/include/cpp/jank/runtime/detail/native_array_map.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/detail/native_array_map.hpp
@@ -2,6 +2,7 @@
 
 #include <type_traits>
 
+#include <jtl/option.hpp>
 #include <jtl/ref.hpp>
 
 #include <jank/runtime/object.hpp>
@@ -41,7 +42,7 @@ namespace jank::runtime::detail
 
     void erase(object_ref const key);
 
-    object_ref *find(object_ref const key) const;
+    jtl::option<object_ref> find(object_ref const key) const;
 
     uhash to_hash() const;
 

--- a/compiler+runtime/src/cpp/jank/runtime/detail/native_array_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/detail/native_array_map.cpp
@@ -154,7 +154,7 @@ namespace jank::runtime::detail
     insert_unique(key, val);
   }
 
-  object_ref *native_array_map::find(object_ref const key) const
+  jtl::option<object_ref> native_array_map::find(object_ref const key) const
   {
     if(key->type == runtime::object_type::keyword)
     {
@@ -162,7 +162,7 @@ namespace jank::runtime::detail
       {
         if(data[i] == key)
         {
-          return &data[i + 1];
+          return data[i + 1];
         }
       }
     }
@@ -172,11 +172,11 @@ namespace jank::runtime::detail
       {
         if(runtime::equal(data[i], key))
         {
-          return &data[i + 1];
+          return data[i + 1];
         }
       }
     }
-    return nullptr;
+    return {};
   }
 
   void native_array_map::erase(object_ref const key)

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_array_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_array_map.cpp
@@ -29,37 +29,27 @@ namespace jank::runtime::obj
 
   object_ref persistent_array_map::get(object_ref const key) const
   {
-    auto const res(data.find(key));
-    if(res)
-    {
-      return *res;
-    }
-    return jank_nil;
+    return data.find(key).unwrap_or(jank_nil);
   }
 
   object_ref persistent_array_map::get(object_ref const key, object_ref const fallback) const
   {
-    auto const res(data.find(key));
-    if(res)
-    {
-      return *res;
-    }
-    return fallback;
+    return data.find(key).unwrap_or(fallback);
   }
 
   object_ref persistent_array_map::get_entry(object_ref const key) const
   {
     auto const res(data.find(key));
-    if(res)
+    if(res.is_some())
     {
-      return make_box<persistent_vector>(std::in_place, key, *res);
+      return make_box<persistent_vector>(std::in_place, key, res.unwrap());
     }
     return jank_nil;
   }
 
   bool persistent_array_map::contains(object_ref const key) const
   {
-    return data.find(key);
+    return data.find(key).is_some();
   }
 
   object_ref persistent_array_map::assoc(object_ref const key, object_ref const val) const

--- a/compiler+runtime/src/cpp/jank/runtime/obj/transient_array_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/transient_array_map.cpp
@@ -64,37 +64,27 @@ namespace jank::runtime::obj
   object_ref transient_array_map::get(object_ref const key) const
   {
     assert_active();
-    auto const res(data.find(key));
-    if(res)
-    {
-      return *res;
-    }
-    return jank_nil;
+    return data.find(key).unwrap_or(jank_nil);
   }
 
   object_ref transient_array_map::get(object_ref const key, object_ref const fallback) const
   {
-    auto const res(data.find(key));
-    if(res)
-    {
-      return *res;
-    }
-    return fallback;
+    return data.find(key).unwrap_or(fallback);
   }
 
   object_ref transient_array_map::get_entry(object_ref const key) const
   {
     auto const res(data.find(key));
-    if(res)
+    if(res.is_some())
     {
-      return make_box<persistent_vector>(std::in_place, key, *res);
+      return make_box<persistent_vector>(std::in_place, key, res.unwrap());
     }
     return jank_nil;
   }
 
   bool transient_array_map::contains(object_ref const key) const
   {
-    return data.find(key);
+    return data.find(key).is_some();
   }
 
   object_ref transient_array_map::assoc_in_place(object_ref const key, object_ref const value)


### PR DESCRIPTION
I noticed that `hash-map` was working just fine for this use case and updated the `array-map` implementation to mirror it.

Before
```clojure
(contains? {:a nil} :a) ; false
(get {:a nil} :a :foo) ; :foo
(find {:a nil} :a) ; nil
```

After:
```clojure
(contains? {:a nil} :a) ; true
(get {:a nil} :a :foo) ; nil
(find {:a nil} :a) ; [:a nil]
```