### PR TITLE
Switch to large code model

### DIFF
--- a/compiler+runtime/src/cpp/jank/jit/processor.cpp
+++ b/compiler+runtime/src/cpp/jank/jit/processor.cpp
@@ -173,16 +173,8 @@ namespace jank::jit
 
     //util::println("jit flags {}", args);
 
-#ifdef JANK_SANITIZE
-    /* ASan leads to larger code size, which can run us up against the 32 bit limit of the
-     * default 'small' JIT code model. When we know we're running ASan, we want to opt
-     * into the 'large' code model instead. This may have some marginal perf impact, but
-     * for ASan builds, that's not a problem. */
     interpreter.reset(static_cast<Cpp::Interpreter *>(
       Cpp::CreateInterpreter(args, {}, vfs, static_cast<int>(llvm::CodeModel::Large))));
-#else
-    interpreter.reset(static_cast<Cpp::Interpreter *>(Cpp::CreateInterpreter(args, {}, vfs)));
-#endif
 
     /* Enabling perf support requires registering a couple of plugins with LLVM. These
      * plugins will generate files which perf can then use to inject additional info


### PR DESCRIPTION
While building the prototypes for the Macroexpand deep conf. I ended up out reaching the LLVM code model in which case the following changes were suggested.

This might be too simple a change I've made, but keeping this PR open so that what all things are actually required for it will be made.