### PR TITLE
Start analyzing & evaluating `meta`

### DIFF
--- a/compiler+runtime/include/cpp/jank/analyze/expr/def.hpp
+++ b/compiler+runtime/include/cpp/jank/analyze/expr/def.hpp
@@ -21,12 +21,14 @@ namespace jank::analyze::expr
         local_frame_ptr frame,
         bool needs_box,
         runtime::obj::symbol_ref name,
+        jtl::option<expression_ref> const &meta,
         jtl::option<expression_ref> const &value);
 
     runtime::object_ref to_runtime_data() const override;
     void walk(std::function<void(jtl::ref<expression>)> const &f) override;
 
     runtime::obj::symbol_ref name{};
+    jtl::option<expression_ref> meta;
     /* TODO: Rename to value_expr. */
     jtl::option<expression_ref> value;
   };

--- a/compiler+runtime/src/cpp/jank/analyze/expr/def.cpp
+++ b/compiler+runtime/src/cpp/jank/analyze/expr/def.cpp
@@ -9,9 +9,11 @@ namespace jank::analyze::expr
            local_frame_ptr const frame,
            bool const needs_box,
            runtime::obj::symbol_ref const name,
+           jtl::option<expression_ref> const &meta,
            jtl::option<expression_ref> const &value)
     : expression{ expr_kind, position, frame, needs_box }
     , name{ name }
+    , meta{ meta }
     , value{ value }
   {
   }

--- a/compiler+runtime/src/cpp/jank/analyze/processor.cpp
+++ b/compiler+runtime/src/cpp/jank/analyze/processor.cpp
@@ -1335,28 +1335,28 @@ namespace jank::analyze
       qualified_sym = qualified_sym->with_meta(meta_with_doc);
     }
 
+    jtl::option<expression_ref> meta{};
+
     /* Lift this so it can be used during codegen. */
     /* TODO: I don't think lifting meta is actually needed anymore. Verify. */
     if(qualified_sym->meta.is_some())
     {
       current_frame->lift_constant(qualified_sym->meta.unwrap());
+      auto const meta_result{ analyze(qualified_sym->meta.unwrap(),
+                                      current_frame,
+                                      expression_position::value,
+                                      fn_ctx,
+                                      true) };
+
+      if(meta_result.is_err())
+      {
+        return meta_result;
+      }
+
+      meta = meta_result.expect_ok();
     }
 
-    auto const meta{
-      analyze(qualified_sym->meta.unwrap(), current_frame, expression_position::value, fn_ctx, true)
-    };
-
-    if(meta.is_err())
-    {
-      return meta;
-    }
-
-    return jtl::make_ref<expr::def>(position,
-                                    current_frame,
-                                    true,
-                                    qualified_sym,
-                                    meta.expect_ok(),
-                                    value_expr);
+    return jtl::make_ref<expr::def>(position, current_frame, true, qualified_sym, meta, value_expr);
   }
 
   processor::expression_result

--- a/compiler+runtime/src/cpp/jank/analyze/processor.cpp
+++ b/compiler+runtime/src/cpp/jank/analyze/processor.cpp
@@ -1342,7 +1342,21 @@ namespace jank::analyze
       current_frame->lift_constant(qualified_sym->meta.unwrap());
     }
 
-    return jtl::make_ref<expr::def>(position, current_frame, true, qualified_sym, value_expr);
+    auto const meta{
+      analyze(qualified_sym->meta.unwrap(), current_frame, expression_position::value, fn_ctx, true)
+    };
+
+    if(meta.is_err())
+    {
+      return meta;
+    }
+
+    return jtl::make_ref<expr::def>(position,
+                                    current_frame,
+                                    true,
+                                    qualified_sym,
+                                    meta.expect_ok(),
+                                    value_expr);
   }
 
   processor::expression_result

--- a/compiler+runtime/src/cpp/jank/codegen/llvm_processor.cpp
+++ b/compiler+runtime/src/cpp/jank/codegen/llvm_processor.cpp
@@ -829,16 +829,14 @@ namespace jank::codegen
       }
     }
 
-    if(expr->name->meta.is_some())
+    if(expr->meta.is_some())
     {
       auto const set_meta_fn_type(
         llvm::FunctionType::get(ctx->builder->getVoidTy(),
                                 { ctx->builder->getPtrTy(), ctx->builder->getPtrTy() },
                                 false));
       auto const set_meta_fn(llvm_module->getOrInsertFunction("jank_set_meta", set_meta_fn_type));
-
-      auto const meta_val(
-        gen_global_from_read_string(strip_source_from_meta(expr->name->meta.unwrap())));
+      auto const meta_val(gen(expr->meta.unwrap(), arity));
       ctx->builder->CreateCall(set_meta_fn, { ref, meta_val });
     }
 

--- a/compiler+runtime/src/cpp/jank/evaluate.cpp
+++ b/compiler+runtime/src/cpp/jank/evaluate.cpp
@@ -276,7 +276,7 @@ namespace jank::evaluate
   object_ref eval(expr::def_ref const expr)
   {
     auto var(__rt_ctx->intern_var(expr->name).expect_ok());
-    var->meta = expr->name->meta;
+    var->meta = some(eval(expr->meta.unwrap()));
 
     auto const meta(var->meta.unwrap_or(jank_nil));
     auto const dynamic(get(meta, __rt_ctx->intern_keyword("dynamic").expect_ok()));

--- a/compiler+runtime/src/cpp/jank/evaluate.cpp
+++ b/compiler+runtime/src/cpp/jank/evaluate.cpp
@@ -276,7 +276,11 @@ namespace jank::evaluate
   object_ref eval(expr::def_ref const expr)
   {
     auto var(__rt_ctx->intern_var(expr->name).expect_ok());
-    var->meta = some(eval(expr->meta.unwrap()));
+
+    if(expr->meta.is_some())
+    {
+      var->meta = some(eval(expr->meta.unwrap()));
+    }
 
     auto const meta(var->meta.unwrap_or(jank_nil));
     auto const dynamic(get(meta, __rt_ctx->intern_keyword("dynamic").expect_ok()));

--- a/compiler+runtime/test/jank/form/def/pass-meta.jank
+++ b/compiler+runtime/test/jank/form/def/pass-meta.jank
@@ -8,4 +8,14 @@
 (assert (= one 'one))
 (assert (= (:doc (meta #'one)) nil))
 
+; Analysis with global variables
+(def foo 42)
+(def ^{:pp #(println foo)} bar 0)
+(assert (= ((-> #'bar meta :pp)) 42))
+
+; Analysis with local variables.
+(let* [foo 42]
+  (def ^{:pp #(println foo)} bar 0)
+  (assert (= ((-> #'bar meta :pp)) 42)))
+
 :success


### PR DESCRIPTION
### Description

We should begin analyzing the metadata as well. At present, we store the metadata source directly without proper analysis or evaluation, resulting in the following code executing despite being semantically incorrect:

```jank
user=> (def ^{:pp #(println foo)} bar 0)
#'user/bar

user=> (meta bar)
nil

user=> (meta #'bar)
{:jank/source {:file "/var/folders/xd/9v1dcg0d46l7d19830vq0lhc0000gn/T/jank-repl-fYkERF", :start {:offset 27, :line 1, :col 28}, :end {:offset 30, :line 1, :col 31}}, :pp (fn* [] (println foo))}

user=> ((-> #'bar meta :pp))
Uncaught exception: Invalid call with 0 args to: (fn* [] (println foo))
```

There are two issues being highlighted here:
1. Although the `foo` symbol is not in scope during the definition of the `bar` var, jank does not emit any analysis failure warnings.
2. Due to lack of evaluation currently the `:pp` key in the metadata of the `bar` var contains the source code instead of a compiled function, preventing us from invoking the function.

### Goal

Within the scope of this PR I wish to start analyzing the metadata such that the above cases behave as would be expected:

```jank
user=> (def ^{:pp #(println foo)} bar 0)
─ analyze/unresolved-symbol ────────────────────────────────────────────────────────────────────────
error: Unable to resolve symbol 'foo'.

─────┬──────────────────────────────────────────────────────────────────────────────────────────────
     │ /var/folders/xd/9v1dcg0d46l7d19830vq0lhc0000gn/T/jank-repl-hKkVT2
─────┼──────────────────────────────────────────────────────────────────────────────────────────────
  1  │ (def ^{:pp #(println foo)} bar 0)
     │                      ^^^ Found here.
─────┴──────────────────────────────────────────────────────────────────────────────────────────────

user=> (def foo 0)
#'user/foo

user=> (def ^{:pp #(println foo)} bar 0)
#'user/bar

user=> (meta #'bar)
{:jank/source {:file "/var/folders/xd/9v1dcg0d46l7d19830vq0lhc0000gn/T/jank-repl-hKkVT2", :start {:offset 27, :line 1, :col 28}, :end {:offset 30, :line 1, :col 31}}, :pp #object [user/user-fn-53 jit_function 0x10ec383f8]}

user=> ((-> #'bar meta :pp))
0
nil
```

---

### Fixes

Resolves https://github.com/jank-lang/jank/issues/197.