### PR TITLE
Update depth in submodule update in build.md

### DIFF
--- a/compiler+runtime/doc/build.md
+++ b/compiler+runtime/doc/build.md
@@ -43,10 +43,10 @@ export CPPFLAGS="-I/opt/homebrew/opt/llvm/include ${CPPFLAGS}"
 Clone the repo as follows:
 
 ```bash
-git clone --depth 1 --single-branch --shallow-submodules --recurse-submodules https://github.com/jank-lang/jank.git
+git clone --recurse-submodules https://github.com/jank-lang/jank.git
 
 # If you didn't recurse submodules when cloning, you'll need to run this.
-git submodule update --init --recursive --depth 100 --jobs 8
+git submodule update --init --recursive --jobs 8
 ```
 
 ## Compiling Clang/LLVM


### PR DESCRIPTION
Increased the depth for submodule update from 1 to 100 because it was giving an error locally when using depth of 1 as it was unable to fetch older commits.