### PR TITLE
fix: odd? on negative numbers works properly

### DIFF
--- a/compiler+runtime/src/cpp/jank/runtime/core/math.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/math.cpp
@@ -718,7 +718,7 @@ namespace jank::runtime
   bool is_odd(object_ref const l)
   {
     return visit_type<obj::integer>(
-      [=](auto const typed_l) -> bool { return typed_l->data % 2 == 1; },
+      [=](auto const typed_l) -> bool { return typed_l->data % 2 != 0; },
       l);
   }
 


### PR DESCRIPTION
Just a simple fix that works with negative numbers. Fixes #512 