### PR TITLE
Link to LLVM's custom libundwind

### DIFF
--- a/compiler+runtime/CMakeLists.txt
+++ b/compiler+runtime/CMakeLists.txt
@@ -112,7 +112,9 @@ set(
   )
 
 if (NOT jank_local_clang)
-  list(APPEND jank_linker_flags -L/opt/homebrew/opt/llvm/lib -L/opt/homebrew/opt/llvm/lib/c++)
+  # On macOS, we need to link to LLVM's custom libunwind, instead of the system's. Otherwise,
+  # we're unable to catch exceptions thrown across JIT compiled frames.
+  list(APPEND jank_linker_flags -L/opt/homebrew/opt/llvm/lib -L/opt/homebrew/opt/llvm/lib/c++ -L/opt/homebrew/opt/llvm/lib/unwind)
 endif ()
 
 # If the user opts into a specific build type, we will provide sane defaults. However, for


### PR DESCRIPTION
On MacOS when we don't explicitly link to `libunwind` we are unable to catch exceptions across JIT frames.

```
...
testing file test/jank/form/throw/throw-top-level.jank => success
...
testing file test/jank/form/throw/throw-return-position.jank => libc++abi: terminating due to uncaught exception of type jank::runtime::oref<jank::runtime::object>
./bin/test: line 10: 13840 Abort trap: 6           "${here}/../build/jank-test" "$@"
```