### PR TITLE
Small tweaks to get AOT working on MacOS.

### DIFF
--- a/compiler+runtime/src/cpp/jank/aot/processor.cpp
+++ b/compiler+runtime/src/cpp/jank/aot/processor.cpp
@@ -237,6 +237,22 @@ int main(int argc, const char** argv)
       compiler_args.push_back(strdup(lib));
     }
 
+    /* User-specified libraries from -l flags. */
+    for(auto const &lib : util::cli::opts.libs)
+    {
+      compiler_args.push_back(strdup(util::format("-l{}", lib).c_str()));
+    }
+
+    /* macOS requires framework linking for OpenGL/GUI applications. */
+    if constexpr(jtl::current_platform == jtl::platform::macos_like)
+    {
+      for(auto const &framework : { "OpenGL", "Cocoa", "IOKit", "CoreFoundation" })
+      {
+        compiler_args.push_back(strdup("-framework"));
+        compiler_args.push_back(strdup(framework));
+      }
+    }
+
     /* On non-macOS platforms, explicitly link libstdc++.
      * macOS uses libc++ implicitly via Clang. */
     if constexpr(jtl::current_platform != jtl::platform::macos_like)

--- a/compiler+runtime/src/cpp/jank/jit/processor.cpp
+++ b/compiler+runtime/src/cpp/jank/jit/processor.cpp
@@ -30,7 +30,7 @@ namespace jank::jit
   static jtl::immutable_string default_shared_lib_name(jtl::immutable_string const &lib)
 #if defined(__APPLE__)
   {
-    return util::format("{}.dylib", lib);
+    return util::format("lib{}.dylib", lib);
   }
 #elif defined(__linux__)
   {


### PR DESCRIPTION
Some tweaks I had to make (with AI) to get my project to AOT compile with Jank. We can delete this PR, just wanted to be able to point to the changes for sanity checking.

# Jank AOT Library Linking Fix

## Problem

When using `jank compile` for AOT compilation, user-specified libraries via `-l` flags were not being passed to the linker. This caused "undefined symbols" errors for any external libraries (e.g., GLFW, ozz-animation, etc.).

## Root Cause

Two issues were identified:

### 1. User libraries not passed to linker (`aot/processor.cpp`)

The AOT processor iterated through `util::cli::opts.library_dirs` to add `-L` flags, but never iterated through `util::cli::opts.libs` to add `-l` flags. Only hardcoded jank dependencies were being linked.

**File:** `src/cpp/jank/aot/processor.cpp`

**Fix:** Added a loop to pass user-specified libraries to the linker (after line 238):

```cpp
/* User-specified libraries from -l flags. */
for(auto const &lib : util::cli::opts.libs)
{
  compiler_args.push_back(strdup(util::format("-l{}", lib).c_str()));
}
```

### 2. macOS JIT library name mismatch (`jit/processor.cpp`)

On macOS, the JIT's `default_shared_lib_name()` function was generating `{lib}.dylib` (e.g., `glfw.3.dylib`), but actual library files follow the convention `lib{lib}.dylib` (e.g., `libglfw.3.dylib`). This caused JIT to fail finding libraries even when they existed in the search paths.

The linker's `-l` flag expects the base name (e.g., `-lglfw.3`) and automatically prepends `lib` and appends `.dylib`, so users naturally specify library names without the `lib` prefix.

**File:** `src/cpp/jank/jit/processor.cpp`

**Fix:** Changed the macOS library name format to include the `lib` prefix:

```cpp
static jtl::immutable_string default_shared_lib_name(jtl::immutable_string const &lib)
#if defined(__APPLE__)
{
  return util::format("lib{}.dylib", lib);  // Was: "{}.dylib"
}
```

### 3. Missing macOS framework linking (`aot/processor.cpp`)

On macOS, OpenGL/GUI applications require linking against system frameworks (OpenGL, Cocoa, IOKit, CoreFoundation). These weren't being included in the AOT link step.

**File:** `src/cpp/jank/aot/processor.cpp`

**Fix:** Added macOS framework linking after user libraries:

```cpp
/* macOS requires framework linking for OpenGL/GUI applications. */
if constexpr(jtl::current_platform == jtl::platform::macos_like)
{
  for(auto const &framework : { "OpenGL", "Cocoa", "IOKit", "CoreFoundation" })
  {
    compiler_args.push_back(strdup("-framework"));
    compiler_args.push_back(strdup(framework));
  }
}
```

## Usage After Fix

Users can now specify libraries in the standard format:

```bash
jank -Llibs/mylib/lib -lmylib compile my.module -o output
```

Both JIT (for analysis during compilation) and the final linker will correctly find `libs/mylib/lib/libmylib.dylib`.

On macOS, OpenGL applications will automatically link against required system frameworks.
