### PR TITLE
fix: Add zlib as Debian Dependency

### DIFF
--- a/compiler+runtime/bin/jank/compiler+runtime/package.clj
+++ b/compiler+runtime/bin/jank/compiler+runtime/package.clj
@@ -19,7 +19,7 @@
 Version: %s
 Architecture: amd64
 Maintainer: Jeaye Wilkerson <jeaye@jank-lang.org>
-Depends: libssl-dev, gcc, libbz2-dev, libzstd-dev, libxml2-dev, libstdc++-14-dev
+Depends: libssl-dev, gcc, libbz2-dev, libzstd-dev, libxml2-dev, libstdc++-14-dev, zlib1g-dev
 Description: The native Clojure dialect hosted on LLVM with seamless C++ interop.
 " jank-version)]
     (util/quiet-shell {:dir compiler+runtime-dir


### PR DESCRIPTION
Trying to compile a project on a fresh Ubuntu install with Leiningen failed to link.
This fixes it by adding zlib as a dependency.

```
  /usr/bin/ld: cannot find -lz: No such file or directory
─ system/failure ───────────────────────────────────────────────────────────────────────────────────
error: Clang failed with errors.error:  linker command failed with exit code 1 (use -v to see       
       invocation)
```