### PR TITLE
Fix `to_string` implementations of runtime function objects

### DIFF
--- a/compiler+runtime/src/cpp/jank/runtime/obj/deferred_cpp_function.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/deferred_cpp_function.cpp
@@ -27,7 +27,7 @@ namespace jank::runtime::obj
 
   void deferred_cpp_function::to_string(jtl::string_builder &buff) const
   {
-    auto const name(get(meta, __rt_ctx->intern_keyword("name").expect_ok()));
+    auto const name(meta->get(__rt_ctx->intern_keyword("name").expect_ok()));
     util::format_to(
       buff,
       "#object [{} {} {}]",
@@ -47,7 +47,7 @@ namespace jank::runtime::obj
       return apply_to(compiled_fn, args);
     }
 
-    //auto const name(get(meta, __rt_ctx->intern_keyword("name").expect_ok()));
+    // auto const name(meta->get(__rt_ctx->intern_keyword("name").expect_ok()));
     //util::println(
     //  "lazily creating {}",
     //  (name->type == object_type::nil ? "unknown" : try_object<persistent_string>(name)->data));

--- a/compiler+runtime/src/cpp/jank/runtime/obj/jit_closure.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/jit_closure.cpp
@@ -31,7 +31,7 @@ namespace jank::runtime::obj
 
   void jit_closure::to_string(jtl::string_builder &buff) const
   {
-    auto const name(get(meta, __rt_ctx->intern_keyword("name").expect_ok()));
+    auto const name(meta->get(__rt_ctx->intern_keyword("name").expect_ok()));
     util::format_to(
       buff,
       "#object [{} {} {}]",

--- a/compiler+runtime/src/cpp/jank/runtime/obj/jit_function.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/jit_function.cpp
@@ -30,7 +30,7 @@ namespace jank::runtime::obj
 
   void jit_function::to_string(jtl::string_builder &buff) const
   {
-    auto const name(get(meta, __rt_ctx->intern_keyword("name").expect_ok()));
+    auto const name(meta->get(__rt_ctx->intern_keyword("name").expect_ok()));
     util::format_to(
       buff,
       "#object [{} {} {}]",

--- a/compiler+runtime/src/cpp/jank/runtime/obj/native_function_wrapper.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/native_function_wrapper.cpp
@@ -29,7 +29,7 @@ namespace jank::runtime::obj
 
   void native_function_wrapper::to_string(jtl::string_builder &buff) const
   {
-    auto const name(get(meta, __rt_ctx->intern_keyword("name").expect_ok()));
+    auto const name(meta->get(__rt_ctx->intern_keyword("name").expect_ok()));
     util::format_to(buff,
                     "#object [{} {} {}]",
                     (name.is_nil() ? "unknown" : try_object<persistent_string>(name)->data),


### PR DESCRIPTION
```jank
user=> (defn foo [])
#'user/foo

user=> [foo]
[#object [user/foo deferred_cpp_function 0x10fa3f210]]

user=> {foo 0}
{#object [user/foo deferred_cpp_function 0x10fa3f210] 0}

user=> {0 foo}
{0 #object [user/foo deferred_cpp_function 0x10fa3f210]}

user=> #{foo}
#{#object [user/foo deferred_cpp_function 0x10fa3f210]}
```

---

Resolves https://github.com/jank-lang/jank/discussions/689.