### PR TITLE
Fix static member access mismatch between analysis and codegen

### DIFF
--- a/compiler+runtime/src/cpp/jank/codegen/llvm_processor.cpp
+++ b/compiler+runtime/src/cpp/jank/codegen/llvm_processor.cpp
@@ -2680,7 +2680,8 @@ namespace jank::codegen
     /* For static variables that are non-copyable, we can't use MakeAotCallable (which copies).
      * Instead, create a wrapper function that returns a pointer to the variable.
      * Check if the type is copyable by seeing if it can be constructed from itself.  */
-    bool const is_copyable{ Cpp::IsConstructible(expr->type, expr->type) };
+    auto const underlying_type{ Cpp::GetNonReferenceType(expr->type) };
+    bool const is_copyable{ Cpp::IsConstructible(underlying_type, underlying_type) };
     if(expr->val_kind == expr::cpp_value::value_kind::variable && Cpp::IsVariable(expr->scope)
        && !is_copyable)
     {


### PR DESCRIPTION
# Before fix: 18 LLVM IR failures:
```
Detailed Failure Reports (18 Tests)
● test/jank/cpp/closure/pass-convertible.jank (llvm-ir, 0ms)
  ↳ Assertion Failed
● test/jank/cpp/global-value/pass-static.jank (llvm-ir, 11ms)
  ↳ Crashed (Segfault - Sig 11)
● test/jank/cpp/global-value/pass-static-non-copyable.jank (llvm-ir, 10ms)
  ↳ Crashed (Abort - Sig 6)
● test/jank/cpp/member/pass-static.jank (llvm-ir, 14ms)
  ↳ Crashed (Segfault - Sig 11)
● test/jank/cpp/auto-box/pass-closure.jank (llvm-ir, 0ms)
  ↳ Assertion Failed
● test/jank/cpp/auto-box/pass-reference-input.jank (llvm-ir, 44ms)
  ↳ Crashed (Segfault - Sig 11)
● test/jank/cpp/literal-value/pass-string-literal.jank (llvm-ir, 55ms)
  ↳ Crashed (Segfault - Sig 11)
● test/jank/cpp/preprocessor/pass-normal.jank (llvm-ir, 63ms)
  ↳ Crashed (Segfault - Sig 11)
● test/jank/cpp/preprocessor/pass-unqualified.jank (llvm-ir, 63ms)
  ↳ Crashed (Segfault - Sig 11)
● test/jank/cpp/operator/aget/pass-binary-return-reference.jank (llvm-ir, 52ms)
  ↳ Assertion Failed
● test/jank/cpp/operator/aget/pass-binary-compatible-types.jank (llvm-ir, 54ms)
  ↳ Assertion Failed
● test/jank/cpp/operator/plusplus/pass-unary-pointer.jank (llvm-ir, 33ms)
  ↳ Crashed (Abort - Sig 6)
● test/jank/cpp/operator/minusminus/pass-unary-pointer.jank (llvm-ir, 36ms)
  ↳ Crashed (Abort - Sig 6)
● test/jank/cpp/loop/pass-nested-let.jank (llvm-ir, 55ms)
  ↳ Assertion Failed
● test/jank/cpp/loop/pass-native-binding-custom-type.jank (llvm-ir, 5048ms)
  ↳ Timeout (>5.0s limit)
● test/jank/cpp/loop/pass-native-binding-trait-convertible.jank (llvm-ir, 5019ms)
  ↳ Timeout (>5.0s limit)
● test/jank/cpp/constructor/complex/pass-aggregate-multiple-conversions.jank (llvm-ir, 162ms)
  ↳ Result is not :success: nil
● test/jank/cpp/constructor/complex/pass-aggregate-object.jank (llvm-ir, 0ms)
  ↳ Exception thrown: Unable to find conversion function match for policy 'from_object' with conversion type 
'jank::cpp::constructor::complex::pass_aggregate_object::foo' and input type 
'jank::runtime::oref<jank::runtime::object>'.
```


# After fix: 13 LLVM IR failures:
```
Detailed Failure Reports (13 Tests)
● test/jank/cpp/closure/pass-convertible.jank (llvm-ir, 0ms)
  ↳ Assertion Failed
● test/jank/cpp/call/global/pass-pointer-to-array.jank (llvm-ir, 25ms)
  ↳ Crashed (Segfault - Sig 11)
● test/jank/cpp/auto-box/pass-closure.jank (llvm-ir, 0ms)
  ↳ Assertion Failed
● test/jank/cpp/literal-value/pass-string-literal.jank (llvm-ir, 50ms)
  ↳ Crashed (Segfault - Sig 11)
● test/jank/cpp/preprocessor/pass-normal.jank (llvm-ir, 61ms)
  ↳ Crashed (Segfault - Sig 11)
● test/jank/cpp/preprocessor/pass-unqualified.jank (llvm-ir, 61ms)
  ↳ Crashed (Segfault - Sig 11)
● test/jank/cpp/operator/plusplus/pass-unary-pointer.jank (llvm-ir, 32ms)
  ↳ Crashed (Abort - Sig 6)
● test/jank/cpp/operator/minusminus/pass-unary-pointer.jank (llvm-ir, 38ms)
  ↳ Crashed (Abort - Sig 6)
● test/jank/cpp/loop/pass-nested-let.jank (llvm-ir, 53ms)
  ↳ Assertion Failed
● test/jank/cpp/loop/pass-native-binding-custom-type.jank (llvm-ir, 5029ms)
  ↳ Timeout (>5.0s limit)
● test/jank/cpp/loop/pass-native-binding-trait-convertible.jank (llvm-ir, 5042ms)
  ↳ Timeout (>5.0s limit)
● test/jank/cpp/constructor/complex/pass-aggregate-multiple-conversions.jank (llvm-ir, 110ms)
  ↳ Result is not :success: nil
● test/jank/cpp/constructor/complex/pass-aggregate-object.jank (llvm-ir, 0ms)
  ↳ Exception thrown: Unable to find conversion function match for policy 'from_object' with conversion type 
'jank::cpp::constructor::complex::pass_aggregate_object::foo' and input type 
'jank::runtime::oref<jank::runtime::object>'.
```

# Fixed:

* test/jank/cpp/global-value/pass-static-non-copyable.jank
* test/jank/cpp/member/pass-static.jank
* test/jank/cpp/auto-box/pass-reference-input.jank
* test/jank/cpp/operator/aget/pass-binary-return-reference.jank
* test/jank/cpp/operator/aget/pass-binary-compatible-types.jank

## AI Disclosure
- [x] This PR was assisted by Google Gemini.
- [x] This PR was manually reviewed for accuracy.