### PR TITLE
Update nREPL output to be compatible with Calva jackin

### DIFF
--- a/compiler+runtime/src/jank/jank/nrepl/server/core.jank
+++ b/compiler+runtime/src/jank/jank/nrepl/server/core.jank
@@ -80,7 +80,8 @@
   (let [server* (listen)
         server (cpp/unbox (:* jank.nrepl.server.native_server) server*)]
     (spit ".nrepl-port" (str (.get_port server)))
-    (println (str "jank nREPL server is running on " (.get_endpoint server)))
+    (println "nREPL server started on port" (str (.get_port server))
+             "on host 127.0.0.1 -" (.get_endpoint server))
     (while true
       (let [client* (accept server*)]
         (future (handle-client client*))))))

--- a/compiler+runtime/src/jank/jank/nrepl/server/core.jank
+++ b/compiler+runtime/src/jank/jank/nrepl/server/core.jank
@@ -80,6 +80,8 @@
   (let [server* (listen)
         server (cpp/unbox (:* jank.nrepl.server.native_server) server*)]
     (spit ".nrepl-port" (str (.get_port server)))
+    ;; Certain nREPL clients, such as Calva, depend on this exact string
+    ;; format to assist with setting up a REPL via jack-in.
     (println "nREPL server started on port" (str (.get_port server))
              "on host 127.0.0.1 -" (.get_endpoint server))
     (while true


### PR DESCRIPTION
It appears that [Calva matches against the exact format of the JVM nREPL implementation output](https://github.com/BetterThanTomorrow/calva/blob/6a18844915e4e77f9a89ac6cc97ef44aacb595b9/src/extension-test/unit/nrepl/jack-in-port-detection-test.ts#L7-L15) to assist with setting up a REPL via jackin. There is another problem which I only have a workout for which involves stdout buffering that I get around via: `script -qc 'jank repl' /dev/null`, still looking into it though.