### PR TITLE
Allow nREPL clients to set source info during eval

### DIFF
--- a/compiler+runtime/include/cpp/jank/read/lex.hpp
+++ b/compiler+runtime/include/cpp/jank/read/lex.hpp
@@ -256,7 +256,7 @@ namespace jank::read::lex
 
     processor(jtl::immutable_string_view const &f);
     processor(jtl::immutable_string_view const &f, usize offset);
-    processor(jtl::immutable_string_view const &f, usize line, usize col);
+    processor(jtl::immutable_string_view const &f, source_position const &p);
 
     jtl::result<token, error_ref> next();
     jtl::result<codepoint, error_ref> peek(usize const ahead = 1) const;

--- a/compiler+runtime/include/cpp/jank/read/lex.hpp
+++ b/compiler+runtime/include/cpp/jank/read/lex.hpp
@@ -256,6 +256,7 @@ namespace jank::read::lex
 
     processor(jtl::immutable_string_view const &f);
     processor(jtl::immutable_string_view const &f, usize offset);
+    processor(jtl::immutable_string_view const &f, usize line, usize col);
 
     jtl::result<token, error_ref> next();
     jtl::result<codepoint, error_ref> peek(usize const ahead = 1) const;

--- a/compiler+runtime/include/cpp/jank/runtime/context.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/context.hpp
@@ -84,7 +84,7 @@ namespace jank::runtime
     jtl::option<object_ref> eval_file(jtl::immutable_string const &path);
     jtl::option<object_ref> eval_string(jtl::immutable_string const &code) const;
     jtl::option<object_ref>
-    eval_string(jtl::immutable_string const &code, usize line, usize col) const;
+    eval_string(jtl::immutable_string const &code, read::source_position const &p) const;
     jtl::result<void, error_ref> eval_cpp_string(jtl::immutable_string const &code) const;
     object_ref read_string(jtl::immutable_string const &code,
                            object_ref const reader_opts,

--- a/compiler+runtime/include/cpp/jank/runtime/context.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/context.hpp
@@ -83,6 +83,8 @@ namespace jank::runtime
 
     jtl::option<object_ref> eval_file(jtl::immutable_string const &path);
     jtl::option<object_ref> eval_string(jtl::immutable_string const &code) const;
+    jtl::option<object_ref>
+    eval_string(jtl::immutable_string const &code, usize line, usize col) const;
     jtl::result<void, error_ref> eval_cpp_string(jtl::immutable_string const &code) const;
     object_ref read_string(jtl::immutable_string const &code,
                            object_ref const reader_opts,

--- a/compiler+runtime/src/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/src/cpp/jank/read/lex.cpp
@@ -335,12 +335,13 @@ namespace jank::read::lex
     pos += offset;
   }
 
-  processor::processor(jtl::immutable_string_view const &f, usize const line, usize const col)
+  processor::processor(jtl::immutable_string_view const &f, source_position const &p)
     : pos{ .proc = this }
     , file{ f }
   {
-    pos.line = line;
-    pos.col = col;
+    pos.offset = p.offset;
+    pos.line = p.line;
+    pos.col = p.col;
   }
 
   movable_position &movable_position::operator++()

--- a/compiler+runtime/src/cpp/jank/read/lex.cpp
+++ b/compiler+runtime/src/cpp/jank/read/lex.cpp
@@ -335,6 +335,14 @@ namespace jank::read::lex
     pos += offset;
   }
 
+  processor::processor(jtl::immutable_string_view const &f, usize const line, usize const col)
+    : pos{ .proc = this }
+    , file{ f }
+  {
+    pos.line = line;
+    pos.col = col;
+  }
+
   movable_position &movable_position::operator++()
   {
     jank_debug_assert(offset < proc->file.size());

--- a/compiler+runtime/src/cpp/jank/runtime/context.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/context.cpp
@@ -183,10 +183,11 @@ namespace jank::runtime
     return eval_string(file.expect_ok().view());
   }
 
-  jtl::option<object_ref> context::eval_string(jtl::immutable_string const &code) const
+  jtl::option<object_ref>
+  context::eval_string(jtl::immutable_string const &code, usize const line, usize const col) const
   {
     profile::timer const timer{ "rt eval_string" };
-    read::lex::processor l_prc{ code };
+    read::lex::processor l_prc{ code, line, col };
     read::parse::processor p_prc{ l_prc.begin(), l_prc.end() };
 
     bool no_op{ true };
@@ -279,6 +280,11 @@ namespace jank::runtime
     }
 
     return ret;
+  }
+
+  jtl::option<object_ref> context::eval_string(jtl::immutable_string const &code) const
+  {
+    return eval_string(code, 0, 0);
   }
 
   jtl::result<void, error_ref> context::eval_cpp_string(jtl::immutable_string const &code) const

--- a/compiler+runtime/src/cpp/jank/runtime/context.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/context.cpp
@@ -284,7 +284,7 @@ namespace jank::runtime
 
   jtl::option<object_ref> context::eval_string(jtl::immutable_string const &code) const
   {
-    return eval_string(code, 0, 0);
+    return eval_string(code, 1, 1);
   }
 
   jtl::result<void, error_ref> context::eval_cpp_string(jtl::immutable_string const &code) const

--- a/compiler+runtime/src/cpp/jank/runtime/context.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/context.cpp
@@ -184,10 +184,10 @@ namespace jank::runtime
   }
 
   jtl::option<object_ref>
-  context::eval_string(jtl::immutable_string const &code, usize const line, usize const col) const
+  context::eval_string(jtl::immutable_string const &code, read::source_position const &p) const
   {
     profile::timer const timer{ "rt eval_string" };
-    read::lex::processor l_prc{ code, line, col };
+    read::lex::processor l_prc{ code, p };
     read::parse::processor p_prc{ l_prc.begin(), l_prc.end() };
 
     bool no_op{ true };
@@ -284,7 +284,8 @@ namespace jank::runtime
 
   jtl::option<object_ref> context::eval_string(jtl::immutable_string const &code) const
   {
-    return eval_string(code, 1, 1);
+    read::source_position const p{};
+    return eval_string(code, p);
   }
 
   jtl::result<void, error_ref> context::eval_cpp_string(jtl::immutable_string const &code) const

--- a/compiler+runtime/src/jank/jank/nrepl/server/eval.jank
+++ b/compiler+runtime/src/jank/jank/nrepl/server/eval.jank
@@ -57,9 +57,9 @@ namespace jank::nrepl::server::eval
   ;; C++ and catch the exceptions there.
 
   (let [p (cpp/jank.read.source_position.
-           (cpp/cast cpp/jtl.usize 0)
-           (cpp/cast cpp/jtl.usize line)
-           (cpp/cast cpp/jtl.usize col))]
+           (cpp/jtl.usize 0)
+           (cpp/jtl.usize line)
+           (cpp/jtl.usize col))]
     (cpp/jank.nrepl.server.eval.safe_eval code p)))
 
 (comment

--- a/compiler+runtime/src/jank/jank/nrepl/server/eval.jank
+++ b/compiler+runtime/src/jank/jank/nrepl/server/eval.jank
@@ -6,7 +6,7 @@ namespace jank::nrepl::server::eval
   using namespace jank;
   using namespace jank::runtime;
 
-  inline bool safe_eval(jtl::immutable_string const &code, usize const line, usize const col)
+  inline bool safe_eval(jtl::immutable_string const &code, read::source_position const &p)
   {
     static auto var_1{ __rt_ctx->find_var(\"clojure.core\", \"*1\") };
     static auto var_2{ __rt_ctx->find_var(\"clojure.core\", \"*2\") };
@@ -15,7 +15,7 @@ namespace jank::nrepl::server::eval
 
     try
     {
-      auto const value{ __rt_ctx->eval_string(code, line, col).unwrap() };
+      auto const value{ __rt_ctx->eval_string(code, p).unwrap() };
 
       var_3->set(var_2->deref()).expect_ok();
       var_2->set(var_1->deref()).expect_ok();
@@ -56,7 +56,11 @@ namespace jank::nrepl::server::eval
   ;; error will crash the server. Instead we create a safe evaluation wrapper in
   ;; C++ and catch the exceptions there.
 
-  (cpp/jank.nrepl.server.eval.safe_eval code line col))
+  (let [p (cpp/jank.read.source_position.
+           (cpp/cast cpp/jtl.usize 0)
+           (cpp/cast cpp/jtl.usize line)
+           (cpp/cast cpp/jtl.usize col))]
+    (cpp/jank.nrepl.server.eval.safe_eval code p)))
 
 (comment
   (+ 1 2)

--- a/compiler+runtime/src/jank/jank/nrepl/server/eval.jank
+++ b/compiler+runtime/src/jank/jank/nrepl/server/eval.jank
@@ -6,7 +6,7 @@ namespace jank::nrepl::server::eval
   using namespace jank;
   using namespace jank::runtime;
 
-  inline bool safe_eval(jtl::immutable_string const &code)
+  inline bool safe_eval(jtl::immutable_string const &code, usize const line, usize const col)
   {
     static auto var_1{ __rt_ctx->find_var(\"clojure.core\", \"*1\") };
     static auto var_2{ __rt_ctx->find_var(\"clojure.core\", \"*2\") };
@@ -15,7 +15,7 @@ namespace jank::nrepl::server::eval
 
     try
     {
-      auto const value{ __rt_ctx->eval_string(code).unwrap() };
+      auto const value{ __rt_ctx->eval_string(code, line, col).unwrap() };
 
       var_3->set(var_2->deref()).expect_ok();
       var_2->set(var_1->deref()).expect_ok();
@@ -47,7 +47,7 @@ namespace jank::nrepl::server::eval
 (defn safe-eval
   "Evaluate code similar to `eval`, but catch any errors. Returns whether the
   eval completed successfully. Results can be read on *1 or *e."
-  [code]
+  [code line col]
   ;; TODO(jank): Some jank printing functions bypass std::cout/std::cerr which
   ;; means we can't as easily intercept them. This is unlike java where
   ;; everything goes through System.out/System.err.
@@ -56,7 +56,7 @@ namespace jank::nrepl::server::eval
   ;; error will crash the server. Instead we create a safe evaluation wrapper in
   ;; C++ and catch the exceptions there.
 
-  (cpp/jank.nrepl.server.eval.safe_eval code))
+  (cpp/jank.nrepl.server.eval.safe_eval code line col))
 
 (comment
   (+ 1 2)

--- a/compiler+runtime/src/jank/jank/nrepl/server/handler/eval.jank
+++ b/compiler+runtime/src/jank/jank/nrepl/server/handler/eval.jank
@@ -14,16 +14,17 @@
 (binding [*ns* default-ns]
   (clojure.core/refer-clojure))
 
-(defn- do-eval [ns code inspect?]
+(defn- do-eval [ns code file-path line col inspect?]
   ;; TODO: Once we have threads, we can spawn a background thread to capture and
   ;; send interleaved output during a long eval.
   (let [target-ns        (or (some-> ns symbol find-ns) default-ns)
         ;; do the eval, capturing anything on stdout
         {:keys [ret stdout stderr]} (with-capture
                                       (fn []
-                                        (binding [*ns* target-ns]
+                                        (binding [*ns* target-ns
+                                                  *file* file-path]
                                           ;; the evaluation may change the namespace
-                                          [(safe-eval code) *ns*])))
+                                          [(safe-eval code line col) *ns*])))
         [success res-ns] ret]
     (cond
       ;; Eval results in error. For now, just report the exception as a value.
@@ -48,9 +49,15 @@
 (defmethod handle-message :eval [msg]
   (do-eval (get msg "ns")
            (get msg "code" "")
+           (get msg "file" "NO_SOURCE_PATH")
+           (get msg "line" 0)
+           (get msg "column" 0)
            (some-> (get msg "inspect") parse-boolean)))
 
 (defmethod handle-message :load-file [msg]
   (do-eval (get msg "ns")
            (get msg "file" "")
+           (get msg "file-path" "NO_SOURCE_PATH")
+           (get msg "line" 0)
+           (get msg "column" 0)
            false))

--- a/compiler+runtime/src/jank/jank/nrepl/server/handler/eval.jank
+++ b/compiler+runtime/src/jank/jank/nrepl/server/handler/eval.jank
@@ -14,6 +14,10 @@
 (binding [*ns* default-ns]
   (clojure.core/refer-clojure))
 
+;; NOTE: when eval'ing forms interactively, nREPL clients will send a code snippet
+;; and possibly the location (line/column) in a source file. Using this info during
+;; eval helps preserve correct source information relative to the entire file,
+;; which is useful for things such as error reporting and logging.
 (defn- do-eval [ns code file-path line col inspect?]
   ;; TODO: Once we have threads, we can spawn a background thread to capture and
   ;; send interleaved output during a long eval.

--- a/compiler+runtime/src/jank/jank/nrepl/server/handler/eval.jank
+++ b/compiler+runtime/src/jank/jank/nrepl/server/handler/eval.jank
@@ -50,14 +50,14 @@
   (do-eval (get msg "ns")
            (get msg "code" "")
            (get msg "file" "NO_SOURCE_PATH")
-           (get msg "line" 0)
-           (get msg "column" 0)
+           (get msg "line" 1)
+           (get msg "column" 1)
            (some-> (get msg "inspect") parse-boolean)))
 
 (defmethod handle-message :load-file [msg]
   (do-eval (get msg "ns")
            (get msg "file" "")
            (get msg "file-path" "NO_SOURCE_PATH")
-           (get msg "line" 0)
-           (get msg "column" 0)
+           (get msg "line" 1)
+           (get msg "column" 1)
            false))


### PR DESCRIPTION
Tools such as [`portal.console`](https://github.com/djblue/portal/blob/master/src/portal/console.cljc#L45) and [`taoensso.timbre`](https://github.com/taoensso/encore/blob/master/src/taoensso/encore.cljc#L2412) leverage source info during macro expansion via metadata. When working interactively via nREPL, and eval'ing single forms, preserving this source info keeps these tools working.