### PR TITLE
Fix use-fixtures silently dropped due to (:ns (meta var)) nil

### DIFF
--- a/compiler+runtime/src/jank/clojure/test.jank
+++ b/compiler+runtime/src/jank/clojure/test.jank
@@ -724,7 +724,9 @@
   "Groups vars by their namespace and runs test-var on them with
   appropriate fixtures applied."
   [vars]
-  (doseq [[ns vars] (group-by (comp :ns meta) vars)]
+  ;;FIXME https://github.com/jank-lang/jank/issues/197
+  ;; (:ns (meta var)) is nil in jank; derive the ns from the var's symbol.
+  (doseq [[ns vars] (group-by -workaround-var->ns vars)]
     (let [once-fixture-fn (join-fixtures (::once-fixtures (meta ns)))
           each-fixture-fn (join-fixtures (::each-fixtures (meta ns)))]
       (once-fixture-fn


### PR DESCRIPTION
  group-by (comp :ns meta) collapses all vars under nil because var
  metadata is lossy in jank (#197), so join-fixtures returns
  default-fixture and :once/:each fixtures never run. Swap in the
  existing -workaround-var->ns helper, matching the shim style already
  used at lines 615/635/659 for the same #197 gap.

  Repro: https://github.com/.../jank-bugs/repros/use-fixtures-noop