### PR TITLE
Fix silent SIGSEGV when -l flag names a missing library

### DIFF
--- a/compiler+runtime/src/cpp/jank/jit/processor.cpp
+++ b/compiler+runtime/src/cpp/jank/jit/processor.cpp
@@ -239,7 +239,8 @@ namespace jank::jit
     auto const &load_result{ load_dynamic_libs(util::cli::opts.libs) };
     if(load_result.is_err())
     {
-      throw error::system_failure(load_result.expect_err().c_str());
+      util::println(stderr, "error: {}", load_result.expect_err());
+      std::exit(1);
     }
   }
 


### PR DESCRIPTION
  load_dynamic_libs was called from processor::processor(). On failure it
  threw error::system_failure, which unwound through the constructor and
  triggered CppInternal::Interpreter::~Interpreter in a partially-torn-down
  state, corrupting LLVM state and causing SIGSEGV in llvm_shutdown().

  Move load_dynamic_libs to context::context() body after jit_prc is fully
  constructed. On failure, print a diagnostic to stderr and call std::exit(1)
  to avoid running the interpreter destructor during stack unwinding.