### PR TITLE
lein-jank: support :frameworks and :extra-flags via JANK_EXTRA_FLAGS

### DIFF
--- a/lein-jank/src/leiningen/jank/core.clj
+++ b/lein-jank/src/leiningen/jank/core.clj
@@ -52,7 +52,13 @@
 
 (defn shell-out! [project classpath command compiler-args runtime-args]
   (let [jank (fs/which "jank")
-        env (System/getenv)
+        extra-flags (->> (concat [(System/getenv "JANK_EXTRA_FLAGS")]
+                                 (mapcat (fn [framework] ["-framework" framework])
+                                         (-> project :jank :frameworks))
+                                 (-> project :jank :extra-flags))
+                         (remove nil?)
+                         (string/join " "))
+        project (update project :jank dissoc :frameworks :extra-flags)
         args (concat [jank command "--module-path" classpath]
                      (build-declarative-flags project)
                      compiler-args
@@ -61,11 +67,12 @@
         ; TODO: Better error handling.
         _ (assert (some? jank))
         _ (when @verbose?
-            (println ">" (clojure.string/join " " args)))
+            (println ">" (str "JANK_EXTRA_FLAGS=" (pr-str extra-flags)))
+            (println ">" (string/join " " args)))
         proc (apply ps/shell
                     {:continue true
                      :dir (:root project)
-                     :extra-env env}
+                     :extra-env {"JANK_EXTRA_FLAGS" extra-flags}}
                     args)]
     (when-not (zero? (:exit proc))
       (System/exit (:exit proc)))))


### PR DESCRIPTION

# CLAUDE SAYS

## Summary                                                                                                                                              
                                                                                                    
  Add support for `:frameworks` and `:extra-flags` in the `:jank` section of                                                                              
  `project.clj`. Both are forwarded to the Clang driver through the existing
  `JANK_EXTRA_FLAGS` environment variable that `jit/processor.cpp` already                                                                                
  reads (`processor.cpp:107`), rather than through jank's CLI, which has no                         
  flag for either.                             

  `:frameworks ["Cocoa" "AppKit"]` becomes `-framework Cocoa -framework AppKit`.
  `:extra-flags ["-x" "objective-c++"]` is appended verbatim. Any parent
  `JANK_EXTRA_FLAGS` is preserved so callers can still prepend flags from
  the shell.

  ## Example

  ```clojure
  :jank {:frameworks  ["Cocoa" "AppKit" "Foundation"]
         :extra-flags ["-x" "objective-c++"]
         ...}

  Notes

  - On macOS, linking against system frameworks requires -framework <Name>
  pairs, which there was previously no declarative way to supply.
  - :extra-flags is a general escape hatch for anything Clang accepts that
  doesn't have a dedicated key.

# Sorry for being lazy and letting Claude do work.