### PR TITLE
Allow `(reset! (atom nil) nil)`

### DIFF
--- a/compiler+runtime/src/cpp/jank/runtime/obj/atom.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/atom.cpp
@@ -39,7 +39,6 @@ namespace jank::runtime::obj
 
   object_ref atom::reset(object_ref const o)
   {
-    jank_debug_assert(o.is_some());
     auto const v(val.load());
     val = o.data;
     notify_watches(this, v, o);


### PR DESCRIPTION
I was hitting this check when trying to clear my atoms. I don't think we need this check as any value can be reset into an atom as far as I'm aware.

Jank
```clojure
% jank repl
user=> (reset! (atom nil) nil)
Assertion failed! o.is_some()
```

Clojure
```clojure
% clj
Clojure 1.12.4
user=> (reset! (atom nil) nil)
nil
```

This closes #724.