### PR TITLE
Include stdio info to nREPL client on errors

### DIFF
--- a/compiler+runtime/src/jank/jank/nrepl/server/handler/eval.jank
+++ b/compiler+runtime/src/jank/jank/nrepl/server/handler/eval.jank
@@ -34,8 +34,10 @@
       ;; Eval results in error. For now, just report the exception as a value.
       ;; If we return :exception then CIDER will try to load clojure.stacktrace.
       (not success)
-      {:value  (str *e)
-       :status [:done :eval-error]}
+      [{:out stdout}
+       {:err stderr}
+       {:value  (str *e)
+        :status [:done :eval-error]}]
 
       ;; Client requests an inspection of the last result.
       inspect?


### PR DESCRIPTION
I was struggling to debug `cpp/raw` errors which are only available via [stderr](https://github.com/jank-lang/jank/blob/main/compiler%2Bruntime/src/cpp/jank/jit/processor.cpp#L346-L347). This update allows the nREPL client to provide why you got the error: `"Unable to compile C++ source."`.