### PR TITLE
Add pointer tagging for inline integers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -66,6 +66,7 @@ misc-definitions-in-headers,\
 -readability-use-anyofallof,\
 -readability-enum-initial-value,\
 -readability-use-concise-preprocessor-directives,\
+-performance-no-int-to-ptr,\
 -performance-noexcept-move-constructor,\
 -performance-move-const-arg"
 

--- a/compiler+runtime/CMakeLists.txt
+++ b/compiler+runtime/CMakeLists.txt
@@ -562,6 +562,7 @@ add_library(
   src/cpp/jank/runtime/detail/native_array_map.cpp
   src/cpp/jank/runtime/detail/native_array_blocking_queue.cpp
   src/cpp/jank/runtime/context.cpp
+  src/cpp/jank/runtime/rtti.cpp
   src/cpp/jank/runtime/ns.cpp
   src/cpp/jank/runtime/var.cpp
   src/cpp/jank/runtime/obj/nil.cpp

--- a/compiler+runtime/include/cpp/jank/codegen/api.hpp
+++ b/compiler+runtime/include/cpp/jank/codegen/api.hpp
@@ -14,6 +14,7 @@ jank::runtime::var_ref _jank_var_owned(char const *sym);
 jank::runtime::obj::keyword_ref _jank_keyword(char const * const ns, char const * const name);
 jank::runtime::obj::symbol_ref _jank_symbol(char const * const ns, char const * const name);
 jank::runtime::obj::integer_ref _jank_int(jtl::i64 const i);
+jank::runtime::obj::small_integer_ref _jank_small_int(jtl::i64 const i);
 jank::runtime::obj::real_ref _jank_real(jtl::f64 const r);
 jank::runtime::obj::symbol_ref
 _jank_symbol(jank::runtime::object_ref const meta, char const * const ns, char const * const name);

--- a/compiler+runtime/include/cpp/jank/hash.hpp
+++ b/compiler+runtime/include/cpp/jank/hash.hpp
@@ -76,7 +76,7 @@ namespace jank::hash
       }
       else
       {
-        hash += visit((*it).get());
+        hash += visit(*it);
       }
       ++n;
     }

--- a/compiler+runtime/include/cpp/jank/runtime/behavior/comparable.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/behavior/comparable.hpp
@@ -5,15 +5,15 @@ namespace jank::runtime::behavior
   template <typename T>
   concept comparable = requires(T * const t) {
     /* Returns how this object compares to the specified object. Comparison, unlike equality,
-       * can only be done for objects of the same type. If there's a type mismatch, this function
-       * is expected to throw. There are three cases to handle:
-       *
-       * 1. Comparison should return less than 0 if this object is less than the param
-       * 2. Comparison should return 0 if the objects are equal
-       * 3. Comparison should return greater than 0 if this object is greater than the param
-       *
-       * For sequences, all values need to be considered for comparison.
-       */
+     * can only be done for objects of the same type. If there's a type mismatch, this function
+     * is expected to throw. There are three cases to handle:
+     *
+     * 1. Comparison should return less than 0 if this object is less than the param
+     * 2. Comparison should return 0 if the objects are equal
+     * 3. Comparison should return greater than 0 if this object is greater than the param
+     *
+     * For sequences, all values need to be considered for comparison.
+     */
     { t->compare(std::declval<object const &>()) } -> std::convertible_to<i64>;
   };
 }

--- a/compiler+runtime/include/cpp/jank/runtime/convert/builtin.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/convert/builtin.hpp
@@ -157,19 +157,28 @@ namespace jank::runtime
   requires std::is_enum_v<T>
   struct convert<T>
   {
-    static obj::integer_ref into_object(T const o)
+    static object_ref into_object(T const o)
     {
       return make_box(static_cast<i64>(o));
     }
 
     static T from_object(object_ref const o)
     {
-      return try_object<obj::integer>(o);
+      if(detail::is_small_int(o.data))
+      {
+        return detail::as_int(o.data);
+      }
+      return try_object<obj::integer>(o)->data;
     }
 
     static T from_object(obj::integer_ref const o)
     {
       return o->data;
+    }
+
+    static T from_object(obj::small_integer_ref const o)
+    {
+      return o.data;
     }
   };
 
@@ -179,19 +188,28 @@ namespace jank::runtime
            && !jtl::is_any_same<T, bool, char, char8_t, char16_t, char32_t, wchar_t>)
   struct convert<T>
   {
-    static obj::integer_ref into_object(T const o)
+    static object_ref into_object(T const o)
     {
       return make_box(static_cast<i64>(o));
     }
 
     static T from_object(object_ref const o)
     {
+      if(detail::is_small_int(o.data))
+      {
+        return static_cast<T>(detail::as_int(o.data));
+      }
       return static_cast<T>(try_object<obj::integer>(o)->data);
     }
 
     static T from_object(obj::integer_ref const o)
     {
       return static_cast<T>(o->data);
+    }
+
+    static T from_object(obj::small_integer_ref const o)
+    {
+      return static_cast<T>(o.data);
     }
   };
 

--- a/compiler+runtime/include/cpp/jank/runtime/core/make_box.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/core/make_box.hpp
@@ -97,6 +97,7 @@ namespace jank::runtime
   {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wsign-compare"
+    /* NOLINTNEXTLINE(misc-redundant-expression) */
     if(detail::min_small_integer <= i && i <= detail::max_small_integer)
 #pragma clang diagnostic pop
     {

--- a/compiler+runtime/include/cpp/jank/runtime/core/make_box.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/core/make_box.hpp
@@ -96,11 +96,11 @@ namespace jank::runtime
   inline object_ref make_box(T const i)
   {
     /* TODO: Deal with negative values. */
-    //if(0 <= i && i <= detail::max_small_integer)
-    //{
-    //  //util::println("make_box :: eliding for {}", i);
-    //  return detail::as_ptr<object *>(i);
-    //}
+    if(0 <= i && i <= detail::max_small_integer)
+    {
+      //util::println("make_box :: eliding for {}", i);
+      return detail::as_ptr<object *>(i);
+    }
     return make_box<obj::integer>(static_cast<i64>(i));
   }
 

--- a/compiler+runtime/include/cpp/jank/runtime/core/make_box.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/core/make_box.hpp
@@ -95,10 +95,11 @@ namespace jank::runtime
   [[gnu::flatten, gnu::hot]]
   inline object_ref make_box(T const i)
   {
-    /* TODO: Deal with negative values. */
-    if(0 <= i && i <= detail::max_small_integer)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wsign-compare"
+    if(detail::min_small_integer <= i && i <= detail::max_small_integer)
+#pragma clang diagnostic pop
     {
-      //util::println("make_box :: eliding for {}", i);
       return detail::as_ptr<object *>(i);
     }
     return make_box<obj::integer>(static_cast<i64>(i));

--- a/compiler+runtime/include/cpp/jank/runtime/core/make_box.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/core/make_box.hpp
@@ -9,6 +9,7 @@
 #include <jank/runtime/obj/persistent_string.hpp>
 #include <jank/runtime/obj/character.hpp>
 #include <jank/runtime/obj/big_decimal.hpp>
+#include <jank/util/fmt/print.hpp>
 
 namespace jank::runtime
 {
@@ -23,18 +24,6 @@ namespace jank::runtime
   inline auto make_box(bool const b)
   {
     return b ? jank_true : jank_false;
-  }
-
-  [[gnu::flatten, gnu::hot]]
-  inline auto make_box(int const i)
-  {
-    return make_box<obj::integer>(static_cast<i64>(i));
-  }
-
-  [[gnu::flatten, gnu::hot]]
-  inline auto make_box(i64 const i)
-  {
-    return make_box<obj::integer>(i);
   }
 
   [[gnu::flatten, gnu::hot]]
@@ -53,12 +42,6 @@ namespace jank::runtime
   inline auto make_box(char const i)
   {
     return make_box<obj::character>(i);
-  }
-
-  [[gnu::flatten, gnu::hot]]
-  inline auto make_box(usize const i)
-  {
-    return make_box<obj::integer>(static_cast<i64>(i));
   }
 
   [[gnu::flatten, gnu::hot]]
@@ -110,9 +93,15 @@ namespace jank::runtime
   template <typename T>
   requires std::is_integral_v<T>
   [[gnu::flatten, gnu::hot]]
-  inline auto make_box(T const d)
+  inline object_ref make_box(T const i)
   {
-    return make_box<obj::integer>(d);
+    /* TODO: Deal with negative values. */
+    //if(0 <= i && i <= detail::max_small_integer)
+    //{
+    //  //util::println("make_box :: eliding for {}", i);
+    //  return detail::as_ptr<object *>(i);
+    //}
+    return make_box<obj::integer>(static_cast<i64>(i));
   }
 
   template <typename T>

--- a/compiler+runtime/include/cpp/jank/runtime/core/math.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/core/math.hpp
@@ -39,6 +39,7 @@ namespace jank::runtime
 
   template <typename L, typename R>
   requires(!detail::primitive_number<L> && !detail::primitive_number<R>)
+  [[gnu::always_inline, gnu::flatten, gnu::hot]]
   auto add(L const l, R const r)
   {
     if constexpr(!detail::valid_boxed_math<L> || !detail::valid_boxed_math<R>)
@@ -84,6 +85,7 @@ namespace jank::runtime
 
   template <typename L, typename R>
   requires detail::primitive_number<L>
+  [[gnu::always_inline, gnu::flatten, gnu::hot]]
   auto add(L const l, R const r)
   {
     if constexpr(!detail::valid_boxed_math<R>)
@@ -112,6 +114,7 @@ namespace jank::runtime
 
   template <typename L, typename R>
   requires detail::primitive_number<R>
+  [[gnu::always_inline, gnu::flatten, gnu::hot]]
   auto add(L const l, R const r)
   {
     if constexpr(!detail::valid_boxed_math<L>)
@@ -140,6 +143,7 @@ namespace jank::runtime
 
   template <typename L, typename R>
   requires(detail::primitive_number<L> && detail::primitive_number<R>)
+  [[gnu::always_inline, gnu::flatten, gnu::hot]]
   auto add(L const l, R const r)
   {
     return l + r;
@@ -149,6 +153,7 @@ namespace jank::runtime
 
   template <typename L, typename R>
   requires(!detail::primitive_number<L> && !detail::primitive_number<R>)
+  [[gnu::always_inline, gnu::flatten, gnu::hot]]
   auto sub(L const l, R const r)
   {
     if constexpr(!detail::valid_boxed_math<L> || !detail::valid_boxed_math<R>)
@@ -194,6 +199,7 @@ namespace jank::runtime
 
   template <typename L, typename R>
   requires detail::primitive_number<L>
+  [[gnu::always_inline, gnu::flatten, gnu::hot]]
   auto sub(L const l, R const r)
   {
     if constexpr(!detail::valid_boxed_math<R>)
@@ -222,6 +228,7 @@ namespace jank::runtime
 
   template <typename L, typename R>
   requires detail::primitive_number<R>
+  [[gnu::always_inline, gnu::flatten, gnu::hot]]
   auto sub(L const l, R const r)
   {
     if constexpr(!detail::valid_boxed_math<L>)
@@ -250,6 +257,7 @@ namespace jank::runtime
 
   template <typename L, typename R>
   requires(detail::primitive_number<L> && detail::primitive_number<R>)
+  [[gnu::always_inline, gnu::flatten, gnu::hot]]
   auto sub(L const l, R const r)
   {
     return l - r;
@@ -259,6 +267,7 @@ namespace jank::runtime
 
   template <typename L, typename R>
   requires(!detail::primitive_number<L> && !detail::primitive_number<R>)
+  [[gnu::always_inline, gnu::flatten, gnu::hot]]
   auto div(L const l, R const r)
   {
     if constexpr(!detail::valid_boxed_math<L> || !detail::valid_boxed_math<R>)
@@ -304,6 +313,7 @@ namespace jank::runtime
 
   template <typename L, typename R>
   requires detail::primitive_number<L>
+  [[gnu::always_inline, gnu::flatten, gnu::hot]]
   auto div(L const l, R const r)
   {
     if constexpr(!detail::valid_boxed_math<R>)
@@ -332,6 +342,7 @@ namespace jank::runtime
 
   template <typename L, typename R>
   requires detail::primitive_number<R>
+  [[gnu::always_inline, gnu::flatten, gnu::hot]]
   auto div(L const l, R const r)
   {
     if constexpr(!detail::valid_boxed_math<L>)
@@ -360,6 +371,7 @@ namespace jank::runtime
 
   template <typename L, typename R>
   requires(detail::primitive_number<L> && detail::primitive_number<R>)
+  [[gnu::always_inline, gnu::flatten, gnu::hot]]
   auto div(L const l, R const r)
   {
     return l / r;
@@ -367,6 +379,7 @@ namespace jank::runtime
 
   template <typename L, typename R>
   requires(!detail::primitive_number<L> && !detail::primitive_number<R>)
+  [[gnu::always_inline, gnu::flatten, gnu::hot]]
   auto mul(L const l, R const r)
   {
     if constexpr(!detail::valid_boxed_math<L> || !detail::valid_boxed_math<R>)
@@ -412,6 +425,7 @@ namespace jank::runtime
 
   template <typename L, typename R>
   requires detail::primitive_number<L>
+  [[gnu::always_inline, gnu::flatten, gnu::hot]]
   auto mul(L const l, R const r)
   {
     if constexpr(!detail::valid_boxed_math<R>)
@@ -440,6 +454,7 @@ namespace jank::runtime
 
   template <typename L, typename R>
   requires detail::primitive_number<R>
+  [[gnu::always_inline, gnu::flatten, gnu::hot]]
   auto mul(L const l, R const r)
   {
     if constexpr(!detail::valid_boxed_math<L>)
@@ -468,6 +483,7 @@ namespace jank::runtime
 
   template <typename L, typename R>
   requires(detail::primitive_number<L> && detail::primitive_number<R>)
+  [[gnu::always_inline, gnu::flatten, gnu::hot]]
   auto mul(L const l, R const r)
   {
     return l * r;
@@ -477,6 +493,7 @@ namespace jank::runtime
 
   template <typename L, typename R>
   requires(!detail::primitive_number<L> && !detail::primitive_number<R>)
+  [[gnu::always_inline, gnu::flatten, gnu::hot]]
   bool lt(L const l, R const r)
   {
     if constexpr(!detail::valid_boxed_math<L> || !detail::valid_boxed_math<R>)
@@ -520,6 +537,7 @@ namespace jank::runtime
 
   template <typename L, typename R>
   requires detail::primitive_number<L>
+  [[gnu::always_inline, gnu::flatten, gnu::hot]]
   bool lt(L const l, R const r)
   {
     if constexpr(!detail::valid_boxed_math<R>)
@@ -547,6 +565,7 @@ namespace jank::runtime
 
   template <typename L, typename R>
   requires detail::primitive_number<R>
+  [[gnu::always_inline, gnu::flatten, gnu::hot]]
   bool lt(L const l, R const r)
   {
     if constexpr(!detail::valid_boxed_math<L>)
@@ -574,6 +593,7 @@ namespace jank::runtime
 
   template <typename L, typename R>
   requires(detail::primitive_number<L> && detail::primitive_number<R>)
+  [[gnu::always_inline, gnu::flatten, gnu::hot]]
   bool lt(L const l, R const r)
   {
     return l < r;
@@ -581,6 +601,7 @@ namespace jank::runtime
 
   template <typename L, typename R>
   requires(!detail::primitive_number<L> && !detail::primitive_number<R>)
+  [[gnu::always_inline, gnu::flatten, gnu::hot]]
   bool lte(L const l, R const r)
   {
     if constexpr(!detail::valid_boxed_math<L> || !detail::valid_boxed_math<R>)
@@ -624,6 +645,7 @@ namespace jank::runtime
 
   template <typename L, typename R>
   requires detail::primitive_number<L>
+  [[gnu::always_inline, gnu::flatten, gnu::hot]]
   bool lte(L const l, R const r)
   {
     if constexpr(!detail::valid_boxed_math<R>)
@@ -651,6 +673,7 @@ namespace jank::runtime
 
   template <typename L, typename R>
   requires detail::primitive_number<R>
+  [[gnu::always_inline, gnu::flatten, gnu::hot]]
   bool lte(L const l, R const r)
   {
     if constexpr(!detail::valid_boxed_math<L>)
@@ -678,6 +701,7 @@ namespace jank::runtime
 
   template <typename L, typename R>
   requires(detail::primitive_number<L> && detail::primitive_number<R>)
+  [[gnu::always_inline, gnu::flatten, gnu::hot]]
   bool lte(L const l, R const r)
   {
     return l <= r;
@@ -685,6 +709,7 @@ namespace jank::runtime
 
   template <typename L, typename R>
   requires(!detail::primitive_number<L> && !detail::primitive_number<R>)
+  [[gnu::always_inline, gnu::flatten, gnu::hot]]
   auto min(L const l, R const r)
   {
     if constexpr(!detail::valid_boxed_math<L> || !detail::valid_boxed_math<R>)
@@ -734,6 +759,7 @@ namespace jank::runtime
 
   template <typename L, typename R>
   requires detail::primitive_number<L>
+  [[gnu::always_inline, gnu::flatten, gnu::hot]]
   auto min(L const l, R const r)
   {
     if constexpr(!detail::valid_boxed_math<R>)
@@ -764,6 +790,7 @@ namespace jank::runtime
 
   template <typename L, typename R>
   requires detail::primitive_number<R>
+  [[gnu::always_inline, gnu::flatten, gnu::hot]]
   auto min(L const l, R const r)
   {
     if constexpr(!detail::valid_boxed_math<L>)
@@ -794,6 +821,7 @@ namespace jank::runtime
 
   template <typename L, typename R>
   requires(detail::primitive_number<L> && detail::primitive_number<R>)
+  [[gnu::always_inline, gnu::flatten, gnu::hot]]
   auto min(L const l, R const r)
   {
     return std::min(l, r);
@@ -801,6 +829,7 @@ namespace jank::runtime
 
   template <typename L, typename R>
   requires(!detail::primitive_number<L> && !detail::primitive_number<R>)
+  [[gnu::always_inline, gnu::flatten, gnu::hot]]
   auto max(L const l, R const r)
   {
     if constexpr(!detail::valid_boxed_math<L> || !detail::valid_boxed_math<R>)
@@ -850,6 +879,7 @@ namespace jank::runtime
 
   template <typename L, typename R>
   requires detail::primitive_number<L>
+  [[gnu::always_inline, gnu::flatten, gnu::hot]]
   auto max(L const l, R const r)
   {
     if constexpr(!detail::valid_boxed_math<R>)
@@ -880,6 +910,7 @@ namespace jank::runtime
 
   template <typename L, typename R>
   requires detail::primitive_number<R>
+  [[gnu::always_inline, gnu::flatten, gnu::hot]]
   auto max(L const l, R const r)
   {
     if constexpr(!detail::valid_boxed_math<L>)
@@ -910,6 +941,7 @@ namespace jank::runtime
 
   template <typename L, typename R>
   requires(detail::primitive_number<L> && detail::primitive_number<R>)
+  [[gnu::always_inline, gnu::flatten, gnu::hot]]
   auto max(L const l, R const r)
   {
     return std::max(l, r);

--- a/compiler+runtime/include/cpp/jank/runtime/core/math.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/core/math.hpp
@@ -34,6 +34,9 @@ namespace jank::runtime
                                                     obj::ratio_ref>);
   }
 
+  /* Only for fixed integer sizes (i.e. integer and small_integer). */
+  i64 to_i64(object_ref const o);
+
   template <typename L, typename R>
   requires(!detail::primitive_number<L> && !detail::primitive_number<R>)
   auto add(L const l, R const r)

--- a/compiler+runtime/include/cpp/jank/runtime/core/math.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/core/math.hpp
@@ -845,7 +845,7 @@ namespace jank::runtime
         [](auto const typed_l, auto const r) -> object_ref {
           return visit_number_like(
             [](auto const typed_r, auto const typed_l) -> object_ref {
-              return typed_r->data < typed_l->data ? typed_r.erase() : typed_l.erase();
+              return typed_l->data < typed_r->data ? typed_r.erase() : typed_l.erase();
             },
             r,
             typed_l);
@@ -857,7 +857,7 @@ namespace jank::runtime
     {
       return visit_number_like(
         [](auto const typed_l, auto const r) -> object_ref {
-          return r->data < typed_l->data ? r.erase() : typed_l.erase();
+          return typed_l->data < r->data ? r.erase() : typed_l.erase();
         },
         l,
         r);
@@ -866,7 +866,7 @@ namespace jank::runtime
     {
       return visit_number_like(
         [](auto const typed_r, auto const l) {
-          return typed_r->data < l->data ? typed_r.erase() : l.erase();
+          return l->data < typed_r->data ? typed_r.erase() : l.erase();
         },
         r,
         l);
@@ -893,7 +893,7 @@ namespace jank::runtime
     {
       return visit_number_like(
         [](auto const typed_r, L const l) -> object_ref {
-          return typed_r->data < l ? typed_r.erase() : make_box(l).erase();
+          return l < typed_r->data ? typed_r.erase() : make_box(l).erase();
         },
         r,
         l);
@@ -924,7 +924,7 @@ namespace jank::runtime
     {
       return visit_number_like(
         [](auto const typed_l, R const r) -> object_ref {
-          return r < typed_l ? make_box(r).erase() : typed_l.erase();
+          return typed_l < r ? make_box(r).erase() : typed_l.erase();
         },
         l,
         r);

--- a/compiler+runtime/include/cpp/jank/runtime/core/truthy.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/core/truthy.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <jank/runtime/obj/number.hpp>
+#include <jank/runtime/oref.hpp>
 #include <jank/runtime/obj/nil.hpp>
 
 namespace jank::runtime

--- a/compiler+runtime/include/cpp/jank/runtime/core/truthy.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/core/truthy.hpp
@@ -5,7 +5,6 @@
 
 namespace jank::runtime
 {
-  bool truthy(object const *o);
   bool truthy(object_ref const o);
   bool truthy(obj::nil_ref const);
   bool truthy(obj::boolean_ref const o);
@@ -14,7 +13,7 @@ namespace jank::runtime
   template <typename T>
   requires runtime::behavior::object_like<T>
   [[gnu::always_inline, gnu::flatten, gnu::hot]]
-  inline auto truthy(T const * const d)
+  inline auto truthy(oref<T> const &d)
   {
     if constexpr(std::same_as<T, obj::nil>)
     {
@@ -28,13 +27,5 @@ namespace jank::runtime
     {
       return true;
     }
-  }
-
-  template <typename T>
-  requires runtime::behavior::object_like<T>
-  [[gnu::always_inline, gnu::flatten, gnu::hot]]
-  inline auto truthy(oref<T> const &d)
-  {
-    return truthy(d.erase());
   }
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/atom.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/atom.hpp
@@ -13,7 +13,7 @@ namespace jank::runtime::obj
   struct atom : object
   {
     static constexpr object_type obj_type{ object_type::atom };
-    static constexpr object_behavior obj_behaviors{ object_behavior::none };
+    static constexpr object_behavior obj_behaviors{ object_behavior::compare };
     static constexpr bool pointer_free{ false };
 
     atom();

--- a/compiler+runtime/include/cpp/jank/runtime/obj/big_decimal.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/big_decimal.hpp
@@ -35,7 +35,7 @@ namespace jank::runtime::obj
   struct big_decimal : object
   {
     static constexpr object_type obj_type{ object_type::big_decimal };
-    static constexpr object_behavior obj_behaviors{ object_behavior::none };
+    static constexpr object_behavior obj_behaviors{ object_behavior::compare };
     static constexpr bool pointer_free{ true };
 
     big_decimal();
@@ -56,7 +56,7 @@ namespace jank::runtime::obj
     uhash to_hash() const override;
 
     /* behavior::comparable */
-    i64 compare(object const &) const;
+    i64 compare(object const &) const override;
 
     /* behavior::number_like */
     i64 to_integer() const;

--- a/compiler+runtime/include/cpp/jank/runtime/obj/big_integer.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/big_integer.hpp
@@ -9,7 +9,7 @@ namespace jank::runtime::obj
   struct big_integer : object
   {
     static constexpr object_type obj_type{ object_type::big_integer };
-    static constexpr object_behavior obj_behaviors{ object_behavior::none };
+    static constexpr object_behavior obj_behaviors{ object_behavior::compare };
     static constexpr bool pointer_free{ true };
 
     big_integer();
@@ -30,7 +30,7 @@ namespace jank::runtime::obj
     uhash to_hash() const override;
 
     /* behavior::comparable */
-    i64 compare(object const &) const;
+    i64 compare(object const &) const override;
 
     /* behavior::comparable extended */
     i64 compare(big_integer const &) const;

--- a/compiler+runtime/include/cpp/jank/runtime/obj/integer_range.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/integer_range.hpp
@@ -6,7 +6,6 @@
 
 namespace jank::runtime::obj
 {
-  using integer_ref = oref<struct integer>;
   using cons_ref = oref<struct cons>;
   using integer_range_ref = oref<struct integer_range>;
 
@@ -19,18 +18,21 @@ namespace jank::runtime::obj
     static constexpr bool pointer_free{ false };
     static constexpr bool is_sequential{ true };
 
-    using bounds_check_t = bool (*)(integer_ref const, integer_ref const);
+    using bounds_check_t = bool (*)(object_ref const, object_ref const);
+
+    /* TODO: We can just unbox all of these integers and only box in `first`, since no allocations
+     * will be done anyway. */
 
     /* Constructors are only to be used within integer_range.cpp. Prefer integer_range::create. */
     integer_range();
     integer_range(integer_range &&) noexcept = default;
     integer_range(integer_range const &) = default;
-    integer_range(integer_ref const end);
-    integer_range(integer_ref const start, obj::integer_ref const end);
-    integer_range(integer_ref const start, obj::integer_ref const end, obj::integer_ref const step);
-    integer_range(integer_ref const start,
-                  integer_ref const end,
-                  integer_ref const step,
+    integer_range(object_ref const end);
+    integer_range(object_ref const start, object_ref const end);
+    integer_range(object_ref const start, object_ref const end, object_ref const step);
+    integer_range(object_ref const start,
+                  object_ref const end,
+                  object_ref const step,
                   bounds_check_t bounds_check);
     //integer_range(integer_ptr start,
     //              integer_ptr end,
@@ -39,10 +41,9 @@ namespace jank::runtime::obj
     //              array_chunk_ptr chunk,
     //              integer_range_ptr chunk_next);
 
-    static object_ref create(integer_ref const end);
-    static object_ref create(integer_ref const start, obj::integer_ref const end);
-    static object_ref
-    create(integer_ref const start, obj::integer_ref const end, obj::integer_ref const step);
+    static object_ref create(object_ref const end);
+    static object_ref create(object_ref const start, object_ref const end);
+    static object_ref create(object_ref const start, object_ref const end, object_ref const step);
 
     /* behavior::object_like */
     bool equal(object const &) const override;
@@ -56,7 +57,7 @@ namespace jank::runtime::obj
     integer_range_ref fresh_seq() const;
 
     /* behavior::sequenceable */
-    integer_ref first() const;
+    object_ref first() const;
     integer_range_ref next() const;
 
     /* behavior::sequenceable_in_place */
@@ -78,9 +79,9 @@ namespace jank::runtime::obj
     usize count() const;
 
     /*** XXX: Everything here is immutable after initialization. ***/
-    integer_ref start{};
-    integer_ref end{};
-    integer_ref step{};
+    object_ref start{};
+    object_ref end{};
+    object_ref step{};
     bounds_check_t bounds_check{};
 
     /* TODO: behavior::chunkable */

--- a/compiler+runtime/include/cpp/jank/runtime/obj/integer_range.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/integer_range.hpp
@@ -18,22 +18,16 @@ namespace jank::runtime::obj
     static constexpr bool pointer_free{ false };
     static constexpr bool is_sequential{ true };
 
-    using bounds_check_t = bool (*)(object_ref const, object_ref const);
-
-    /* TODO: We can just unbox all of these integers and only box in `first`, since no allocations
-     * will be done anyway. */
+    using bounds_check_t = bool (*)(i64 const, i64 const);
 
     /* Constructors are only to be used within integer_range.cpp. Prefer integer_range::create. */
     integer_range();
     integer_range(integer_range &&) noexcept = default;
     integer_range(integer_range const &) = default;
-    integer_range(object_ref const end);
-    integer_range(object_ref const start, object_ref const end);
-    integer_range(object_ref const start, object_ref const end, object_ref const step);
-    integer_range(object_ref const start,
-                  object_ref const end,
-                  object_ref const step,
-                  bounds_check_t bounds_check);
+    integer_range(i64 const end);
+    integer_range(i64 const start, i64 const end);
+    integer_range(i64 const start, i64 const end, i64 const step);
+    integer_range(i64 const start, i64 const end, i64 const step, bounds_check_t bounds_check);
     //integer_range(integer_ptr start,
     //              integer_ptr end,
     //              integer_ptr step,
@@ -41,9 +35,9 @@ namespace jank::runtime::obj
     //              array_chunk_ptr chunk,
     //              integer_range_ptr chunk_next);
 
-    static object_ref create(object_ref const end);
-    static object_ref create(object_ref const start, object_ref const end);
-    static object_ref create(object_ref const start, object_ref const end, object_ref const step);
+    static object_ref create(i64 const end);
+    static object_ref create(i64 const start, i64 const end);
+    static object_ref create(i64 const start, i64 const end, i64 const step);
 
     /* behavior::object_like */
     bool equal(object const &) const override;
@@ -79,9 +73,9 @@ namespace jank::runtime::obj
     usize count() const;
 
     /*** XXX: Everything here is immutable after initialization. ***/
-    object_ref start{};
-    object_ref end{};
-    object_ref step{};
+    i64 start{};
+    i64 end{};
+    i64 step{};
     bounds_check_t bounds_check{};
 
     /* TODO: behavior::chunkable */

--- a/compiler+runtime/include/cpp/jank/runtime/obj/integer_range.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/integer_range.hpp
@@ -75,7 +75,7 @@ namespace jank::runtime::obj
     /*** XXX: Everything here is immutable after initialization. ***/
     i64 start{};
     i64 end{};
-    i64 step{};
+    i64 step{ 1 };
     bounds_check_t bounds_check{};
 
     /* TODO: behavior::chunkable */

--- a/compiler+runtime/include/cpp/jank/runtime/obj/keyword.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/keyword.hpp
@@ -10,7 +10,8 @@ namespace jank::runtime::obj
   struct keyword : object
   {
     static constexpr object_type obj_type{ object_type::keyword };
-    static constexpr object_behavior obj_behaviors{ object_behavior::call };
+    static constexpr object_behavior obj_behaviors{ object_behavior::call
+                                                    | object_behavior::compare };
     static constexpr bool pointer_free{ false };
     /* Clojure uses this. No idea. https://github.com/clojure/clojure/blob/master/src/jvm/clojure/lang/Keyword.java */
     static constexpr usize hash_magic{ 0x9e3779b9 };
@@ -29,7 +30,7 @@ namespace jank::runtime::obj
     uhash to_hash() const override;
 
     /* behavior::comparable */
-    i64 compare(object const &) const;
+    i64 compare(object const &) const override;
 
     /* behavior::comparable extended */
     i64 compare(keyword const &) const;
@@ -60,7 +61,7 @@ namespace std
   {
     size_t operator()(jank::runtime::obj::keyword_ref const o) const
     {
-      return o->to_hash();
+      return o.to_hash();
     }
   };
 

--- a/compiler+runtime/include/cpp/jank/runtime/obj/nil.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/nil.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#define JANK_JUST_OBJECT_PLEASE
 #include <jank/runtime/object.hpp>
+#undef JANK_JUST_OBJECT_PLEASE
 
 namespace jank::runtime::obj
 {
@@ -11,7 +13,8 @@ namespace jank::runtime::obj
   struct nil : object
   {
     static constexpr object_type obj_type{ object_type::nil };
-    static constexpr object_behavior obj_behaviors{ object_behavior::get };
+    static constexpr object_behavior obj_behaviors{ object_behavior::get
+                                                    | object_behavior::compare };
     static constexpr bool pointer_free{ true };
 
     nil();
@@ -24,7 +27,7 @@ namespace jank::runtime::obj
     uhash to_hash() const override;
 
     /* behavior::comparable */
-    i64 compare(object const &) const;
+    i64 compare(object const &) const override;
 
     /* behavior::comparable extended */
     i64 compare(nil const &) const;

--- a/compiler+runtime/include/cpp/jank/runtime/obj/number.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/number.hpp
@@ -1,15 +1,15 @@
 #pragma once
 
+#define JANK_JUST_OBJECT_PLEASE
 #include <jank/runtime/object.hpp>
+#undef JANK_JUST_OBJECT_PLEASE
 
 namespace jank::runtime::obj
 {
-  using boolean_ref = oref<struct boolean>;
-
   struct boolean : object
   {
     static constexpr object_type obj_type{ object_type::boolean };
-    static constexpr object_behavior obj_behaviors{ object_behavior::none };
+    static constexpr object_behavior obj_behaviors{ object_behavior::compare };
     static constexpr bool pointer_free{ true };
 
     boolean();
@@ -25,7 +25,7 @@ namespace jank::runtime::obj
     uhash to_hash() const override;
 
     /* behavior::comparable */
-    i64 compare(object const &) const;
+    i64 compare(object const &) const override;
 
     /* behavior::comparable extended */
     i64 compare(boolean const &) const;
@@ -38,12 +38,10 @@ namespace jank::runtime::obj
     bool data{};
   };
 
-  using integer_ref = oref<struct integer>;
-
   struct integer : object
   {
     static constexpr object_type obj_type{ object_type::integer };
-    static constexpr object_behavior obj_behaviors{ object_behavior::none };
+    static constexpr object_behavior obj_behaviors{ object_behavior::compare };
     static constexpr bool pointer_free{ true };
 
     integer();
@@ -59,7 +57,7 @@ namespace jank::runtime::obj
     uhash to_hash() const override;
 
     /* behavior::comparable */
-    i64 compare(object const &) const;
+    i64 compare(object const &) const override;
 
     /* behavior::comparable extended */
     i64 compare(integer const &) const;
@@ -69,16 +67,45 @@ namespace jank::runtime::obj
     f64 to_real() const;
 
     /*** XXX: Everything here is immutable after initialization. ***/
-    /* TODO: Is it faster to have the data first or the base first? */
     i64 data{};
   };
 
-  using real_ref = oref<struct real>;
+  struct small_integer : object
+  {
+    static constexpr object_type obj_type{ object_type::small_integer };
+    static constexpr object_behavior obj_behaviors{ object_behavior::compare };
+    static constexpr bool pointer_free{ true };
+
+    small_integer();
+    small_integer(small_integer &&) noexcept = default;
+    small_integer(small_integer const &) = default;
+    small_integer(i64 const d);
+
+    /* behavior::object_like */
+    bool equal(object const &) const override;
+    jtl::immutable_string to_string() const override;
+    void to_string(jtl::string_builder &buff) const override;
+    jtl::immutable_string to_code_string() const override;
+    uhash to_hash() const override;
+
+    /* behavior::comparable */
+    i64 compare(object const &) const override;
+
+    /* behavior::comparable extended */
+    i64 compare(small_integer const &) const;
+
+    /* behavior::number_like */
+    i64 to_integer() const;
+    f64 to_real() const;
+
+    /*** XXX: Everything here is immutable after initialization. ***/
+    i64 data{};
+  };
 
   struct real : object
   {
     static constexpr object_type obj_type{ object_type::real };
-    static constexpr object_behavior obj_behaviors{ object_behavior::none };
+    static constexpr object_behavior obj_behaviors{ object_behavior::compare };
     static constexpr bool pointer_free{ true };
 
     real();
@@ -94,7 +121,7 @@ namespace jank::runtime::obj
     uhash to_hash() const override;
 
     /* behavior::comparable */
-    i64 compare(object const &) const;
+    i64 compare(object const &) const override;
 
     /* behavior::comparable extended */
     i64 compare(real const &) const;
@@ -106,12 +133,4 @@ namespace jank::runtime::obj
     /*** XXX: Everything here is immutable after initialization. ***/
     f64 data{};
   };
-}
-
-namespace jank::runtime
-{
-  /* NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables) */
-  extern obj::boolean_ref jank_true;
-  /* NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables) */
-  extern obj::boolean_ref jank_false;
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_string.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_string.hpp
@@ -12,7 +12,8 @@ namespace jank::runtime::obj
   struct persistent_string : object
   {
     static constexpr object_type obj_type{ object_type::persistent_string };
-    static constexpr object_behavior obj_behaviors{ object_behavior::get };
+    static constexpr object_behavior obj_behaviors{ object_behavior::get
+                                                    | object_behavior::compare };
     static constexpr bool pointer_free{ false };
 
     persistent_string();
@@ -35,7 +36,7 @@ namespace jank::runtime::obj
     uhash to_hash() const override;
 
     /* behavior::comparable */
-    i64 compare(object const &) const;
+    i64 compare(object const &) const override;
 
     /* behavior::comparable extended */
     i64 compare(persistent_string const &) const;

--- a/compiler+runtime/include/cpp/jank/runtime/obj/persistent_vector.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/persistent_vector.hpp
@@ -13,7 +13,8 @@ namespace jank::runtime::obj
   {
     static constexpr object_type obj_type{ object_type::persistent_vector };
     static constexpr object_behavior obj_behaviors{ object_behavior::call | object_behavior::get
-                                                    | object_behavior::find };
+                                                    | object_behavior::find
+                                                    | object_behavior::compare };
     static constexpr bool pointer_free{ false };
     static constexpr bool is_sequential{ true };
 
@@ -54,7 +55,7 @@ namespace jank::runtime::obj
     uhash to_hash() const override;
 
     /* behavior::comparable */
-    i64 compare(object const &) const;
+    i64 compare(object const &) const override;
 
     /* behavior::comparable extended */
     i64 compare(persistent_vector const &) const;

--- a/compiler+runtime/include/cpp/jank/runtime/obj/ratio.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/ratio.hpp
@@ -29,7 +29,7 @@ namespace jank::runtime::obj
   struct ratio : object
   {
     static constexpr object_type obj_type{ object_type::ratio };
-    static constexpr object_behavior obj_behaviors{ object_behavior::none };
+    static constexpr object_behavior obj_behaviors{ object_behavior::compare };
     static constexpr bool pointer_free{ true };
 
     ratio(ratio &&) noexcept = default;
@@ -46,7 +46,7 @@ namespace jank::runtime::obj
     uhash to_hash() const override;
 
     /* behavior::comparable */
-    i64 compare(object const &) const;
+    i64 compare(object const &) const override;
 
     /* behavior::comparable extended */
     i64 compare(ratio const &) const;
@@ -60,8 +60,8 @@ namespace jank::runtime::obj
   };
 
   object_ref operator+(ratio_data const &l, ratio_data const &r);
-  ratio_ref operator+(integer_ref const l, ratio_data const &r);
-  ratio_ref operator+(ratio_data const &l, integer_ref const r);
+  ratio_data operator+(integer_ref const l, ratio_data const &r);
+  ratio_data operator+(ratio_data const &l, integer_ref const r);
   f64 operator+(real_ref const l, ratio_data const &r);
   f64 operator+(ratio_data const &l, real_ref const r);
 
@@ -81,21 +81,21 @@ namespace jank::runtime::obj
 
   template <typename T>
   requires std::is_integral_v<T>
-  ratio_ref operator+(T const l, ratio_data const &r)
+  ratio_data operator+(T const l, ratio_data const &r)
   {
-    return make_box<ratio>(ratio_data(r.numerator + (l * r.denominator), r.denominator));
+    return ratio_data(r.numerator + (l * r.denominator), r.denominator);
   }
 
   template <typename T>
   requires std::is_integral_v<T>
-  ratio_ref operator+(ratio_data const &l, T const r)
+  ratio_data operator+(ratio_data const &l, T const r)
   {
-    return make_box<ratio>(ratio_data(l.numerator + (r * l.denominator), l.denominator));
+    return ratio_data(l.numerator + (r * l.denominator), l.denominator);
   }
 
   object_ref operator-(ratio_data const &l, ratio_data const &r);
-  ratio_ref operator-(integer_ref const l, ratio_data const &r);
-  ratio_ref operator-(ratio_data const &l, integer_ref const r);
+  ratio_data operator-(integer_ref const l, ratio_data const &r);
+  ratio_data operator-(ratio_data const &l, integer_ref const r);
   f64 operator-(real_ref const l, ratio_data const &r);
   f64 operator-(ratio_data const &l, real_ref const r);
 
@@ -115,16 +115,16 @@ namespace jank::runtime::obj
 
   template <typename T>
   requires std::is_integral_v<T>
-  ratio_ref operator-(T const l, ratio_data const &r)
+  ratio_data operator-(T const l, ratio_data const &r)
   {
-    return make_box<ratio>(ratio_data((l * r.denominator) - r.numerator, r.denominator));
+    return ratio_data((l * r.denominator) - r.numerator, r.denominator);
   }
 
   template <typename T>
   requires std::is_integral_v<T>
-  ratio_ref operator-(ratio_data const &l, T const r)
+  ratio_data operator-(ratio_data const &l, T const r)
   {
-    return make_box<ratio>(ratio_data(l.numerator - (r * l.denominator), l.denominator));
+    return ratio_data(l.numerator - (r * l.denominator), l.denominator);
   }
 
   object_ref operator*(ratio_data const &l, ratio_data const &r);

--- a/compiler+runtime/include/cpp/jank/runtime/obj/symbol.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/symbol.hpp
@@ -12,7 +12,7 @@ namespace jank::runtime::obj
   struct symbol : object
   {
     static constexpr object_type obj_type{ object_type::symbol };
-    static constexpr object_behavior obj_behaviors{ object_behavior::none };
+    static constexpr object_behavior obj_behaviors{ object_behavior::compare };
     static constexpr bool pointer_free{ false };
 
     symbol();
@@ -39,7 +39,7 @@ namespace jank::runtime::obj
     bool equal(symbol const &) const;
 
     /* behavior::comparable */
-    i64 compare(object const &) const;
+    i64 compare(object const &) const override;
 
     /* behavior::comparable extended */
     i64 compare(symbol const &) const;

--- a/compiler+runtime/include/cpp/jank/runtime/object.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/object.hpp
@@ -13,6 +13,7 @@ namespace jank::runtime
 
     boolean,
     integer,
+    small_integer,
     big_integer,
     big_decimal,
     real,
@@ -106,6 +107,8 @@ namespace jank::runtime
         return "boolean";
       case object_type::integer:
         return "integer";
+      case object_type::small_integer:
+        return "small_integer";
       case object_type::big_integer:
         return "big_integer";
       case object_type::big_decimal:
@@ -278,10 +281,10 @@ namespace jank::runtime
     call = 1 << 0,
     get = 1 << 1,
     find = 1 << 2,
+    compare = 1 << 3,
     //associatively_writable,
     //chunkable,
     //collection_like,
-    //comparable,
     //conjable,
     //countable,
     //derefable,
@@ -430,6 +433,19 @@ namespace jank::runtime
     /* behavior::find */
     virtual object_ref find(object_ref key) const;
 
+    /* behavior::compare */
+    /* Returns how this object compares to the specified object. Comparison, unlike equality,
+     * can only be done for objects of the same type. If there's a type mismatch, this function
+     * is expected to throw. There are three cases to handle:
+     *
+     * 1. Comparison should return less than 0 if this object is less than the param
+     * 2. Comparison should return 0 if the objects are equal
+     * 3. Comparison should return greater than 0 if this object is greater than the param
+     *
+     * For sequences, all values need to be considered for comparison.
+     */
+    virtual i64 compare(object const &) const;
+
     object_type type{};
     object_behavior behaviors{ object_behavior::none };
   };
@@ -439,6 +455,8 @@ namespace jank::runtime
     struct nil;
   }
 }
+
+#ifndef JANK_JUST_OBJECT_PLEASE
 
 namespace jank::runtime::behavior
 {
@@ -453,7 +471,7 @@ namespace jank::runtime::behavior
   };
 }
 
-#include <jank/runtime/oref.hpp>
+  #include <jank/runtime/oref.hpp>
 
 namespace jank::runtime
 {
@@ -500,3 +518,5 @@ namespace std
                     jank::runtime::object_ref const rhs) const noexcept;
   };
 }
+
+#endif

--- a/compiler+runtime/include/cpp/jank/runtime/oref.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/oref.hpp
@@ -268,12 +268,12 @@ namespace jank::runtime
           return detail::as_int(data) == detail::as_int(o.data);
         }
 
-        obj::small_integer i{ detail::as_int(data) };
+        obj::small_integer const i{ detail::as_int(data) };
         return o.equal(&i);
       }
       else if(detail::is_small_int(o.data))
       {
-        obj::small_integer i{ detail::as_int(o.data) };
+        obj::small_integer const i{ detail::as_int(o.data) };
         return data->equal(i);
       }
       return data->equal(*o.data);
@@ -283,7 +283,7 @@ namespace jank::runtime
     {
       if(detail::is_small_int(data))
       {
-        obj::small_integer i{ detail::as_int(data) };
+        obj::small_integer const i{ detail::as_int(data) };
         return i.to_string();
       }
       return data->to_string();
@@ -293,7 +293,7 @@ namespace jank::runtime
     {
       if(detail::is_small_int(data))
       {
-        obj::small_integer i{ detail::as_int(data) };
+        obj::small_integer const i{ detail::as_int(data) };
         i.to_string(sb);
         return;
       }
@@ -304,7 +304,7 @@ namespace jank::runtime
     {
       if(detail::is_small_int(data))
       {
-        obj::small_integer i{ detail::as_int(data) };
+        obj::small_integer const i{ detail::as_int(data) };
         return i.to_code_string();
       }
       return data->to_code_string();
@@ -314,7 +314,7 @@ namespace jank::runtime
     {
       if(detail::is_small_int(data))
       {
-        obj::small_integer i{ detail::as_int(data) };
+        obj::small_integer const i{ detail::as_int(data) };
         return i.to_hash();
       }
       return data->to_hash();
@@ -324,7 +324,7 @@ namespace jank::runtime
     {
       if(detail::is_small_int(data))
       {
-        obj::small_integer i{ detail::as_int(data) };
+        obj::small_integer const i{ detail::as_int(data) };
         return i.has_behavior(b);
       }
       return data->has_behavior(b);
@@ -335,8 +335,8 @@ namespace jank::runtime
     {
       if(detail::is_small_int(data))
       {
-        /* TODO */
-        return &_jank_nil;
+        obj::small_integer const i{ detail::as_int(data) };
+        return i.call();
       }
       return data->call();
     }
@@ -345,8 +345,8 @@ namespace jank::runtime
     {
       if(detail::is_small_int(data))
       {
-        /* TODO */
-        return &_jank_nil;
+        obj::small_integer const i{ detail::as_int(data) };
+        return i.call(a1);
       }
       return data->call(a1);
     }
@@ -355,8 +355,8 @@ namespace jank::runtime
     {
       if(detail::is_small_int(data))
       {
-        /* TODO */
-        return &_jank_nil;
+        obj::small_integer const i{ detail::as_int(data) };
+        return i.call(a1, a2);
       }
       return data->call(a1, a2);
     }
@@ -365,8 +365,8 @@ namespace jank::runtime
     {
       if(detail::is_small_int(data))
       {
-        /* TODO */
-        return &_jank_nil;
+        obj::small_integer const i{ detail::as_int(data) };
+        return i.call(a1, a2, a3);
       }
       return data->call(a1, a2, a3);
     }
@@ -376,8 +376,8 @@ namespace jank::runtime
     {
       if(detail::is_small_int(data))
       {
-        /* TODO */
-        return &_jank_nil;
+        obj::small_integer const i{ detail::as_int(data) };
+        return i.call(a1, a2, a3, a4);
       }
       return data->call(a1, a2, a3, a4);
     }
@@ -390,8 +390,8 @@ namespace jank::runtime
     {
       if(detail::is_small_int(data))
       {
-        /* TODO */
-        return &_jank_nil;
+        obj::small_integer const i{ detail::as_int(data) };
+        return i.call(a1, a2, a3, a4, a5);
       }
       return data->call(a1, a2, a3, a4, a5);
     }
@@ -405,8 +405,8 @@ namespace jank::runtime
     {
       if(detail::is_small_int(data))
       {
-        /* TODO */
-        return &_jank_nil;
+        obj::small_integer const i{ detail::as_int(data) };
+        return i.call(a1, a2, a3, a4, a5, a6);
       }
       return data->call(a1, a2, a3, a4, a5, a6);
     }
@@ -421,8 +421,8 @@ namespace jank::runtime
     {
       if(detail::is_small_int(data))
       {
-        /* TODO */
-        return &_jank_nil;
+        obj::small_integer const i{ detail::as_int(data) };
+        return i.call(a1, a2, a3, a4, a5, a6, a7);
       }
       return data->call(a1, a2, a3, a4, a5, a6, a7);
     }
@@ -438,8 +438,8 @@ namespace jank::runtime
     {
       if(detail::is_small_int(data))
       {
-        /* TODO */
-        return &_jank_nil;
+        obj::small_integer const i{ detail::as_int(data) };
+        return i.call(a1, a2, a3, a4, a5, a6, a7, a8);
       }
       return data->call(a1, a2, a3, a4, a5, a6, a7, a8);
     }
@@ -456,8 +456,8 @@ namespace jank::runtime
     {
       if(detail::is_small_int(data))
       {
-        /* TODO */
-        return &_jank_nil;
+        obj::small_integer const i{ detail::as_int(data) };
+        return i.call(a1, a2, a3, a4, a5, a6, a7, a8, a9);
       }
       return data->call(a1, a2, a3, a4, a5, a6, a7, a8, a9);
     }
@@ -475,8 +475,8 @@ namespace jank::runtime
     {
       if(detail::is_small_int(data))
       {
-        /* TODO */
-        return &_jank_nil;
+        obj::small_integer const i{ detail::as_int(data) };
+        return i.call(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10);
       }
       return data->call(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10);
     }
@@ -495,8 +495,8 @@ namespace jank::runtime
     {
       if(detail::is_small_int(data))
       {
-        /* TODO */
-        return &_jank_nil;
+        obj::small_integer const i{ detail::as_int(data) };
+        return i.get(key);
       }
       return data->get(key);
     }
@@ -505,8 +505,8 @@ namespace jank::runtime
     {
       if(detail::is_small_int(data))
       {
-        /* TODO */
-        return &_jank_nil;
+        obj::small_integer const i{ detail::as_int(data) };
+        return i.get(key, fallback);
       }
       return data->get(key, fallback);
     }
@@ -515,8 +515,8 @@ namespace jank::runtime
     {
       if(detail::is_small_int(data))
       {
-        /* TODO */
-        return false;
+        obj::small_integer const i{ detail::as_int(data) };
+        return i.contains(key);
       }
       return data->contains(key);
     }
@@ -526,8 +526,8 @@ namespace jank::runtime
     {
       if(detail::is_small_int(data))
       {
-        /* TODO */
-        return &_jank_nil;
+        obj::small_integer const i{ detail::as_int(data) };
+        return i.find(key);
       }
       return data->find(key);
     }
@@ -544,12 +544,12 @@ namespace jank::runtime
           return (r < l) - (l < r);
         }
 
-        obj::small_integer i{ detail::as_int(data) };
+        obj::small_integer const i{ detail::as_int(data) };
         return o.compare(&i);
       }
       else if(detail::is_small_int(o.data))
       {
-        obj::small_integer i{ detail::as_int(o.data) };
+        obj::small_integer const i{ detail::as_int(o.data) };
         return data->compare(i);
       }
       return data->compare(*o.data);
@@ -771,7 +771,7 @@ namespace jank::runtime
       }
       if(detail::is_small_int(o.data))
       {
-        obj::small_integer i{ detail::as_int(o.data) };
+        obj::small_integer const i{ detail::as_int(o.data) };
         return static_cast<T *>(data)->equal(i);
       }
       return static_cast<T *>(data)->equal(*o.data);
@@ -1013,10 +1013,14 @@ namespace jank::runtime
     /* behavior::compare */
     i64 compare(object_ref const o) const
     {
-      /* TODO: Handle o being small int. */
       if(is_nil())
       {
         return _jank_nil.compare(*o.data);
+      }
+      if(detail::is_small_int(o.data))
+      {
+        obj::small_integer const i{ detail::as_int(o.data) };
+        return static_cast<T *>(data)->compare(i);
       }
       return static_cast<T *>(data)->compare(*o.data);
     }
@@ -1037,7 +1041,6 @@ namespace jank::runtime
     oref(nullptr_t) = delete;
 
     oref(_jank_null) noexcept
-      : data{}
     {
     }
 
@@ -1116,69 +1119,69 @@ namespace jank::runtime
         return data == detail::as_int(o.data);
       }
 
-      obj::small_integer i{ data };
+      obj::small_integer const i{ data };
       return o.equal(&i);
     }
 
     jtl::immutable_string to_string() const
     {
-      obj::small_integer i{ data };
+      obj::small_integer const i{ data };
       return i.to_string();
     }
 
     void to_string(jtl::string_builder &sb) const
     {
-      obj::small_integer i{ data };
+      obj::small_integer const i{ data };
       i.to_string(sb);
     }
 
     jtl::immutable_string to_code_string() const
     {
-      obj::small_integer i{ data };
+      obj::small_integer const i{ data };
       return i.to_code_string();
     }
 
     uhash to_hash() const
     {
-      obj::small_integer i{ data };
+      obj::small_integer const i{ data };
       return i.to_hash();
     }
 
     bool has_behavior(object_behavior const b) const
     {
-      obj::small_integer i{ data };
+      obj::small_integer const i{ data };
       return i.has_behavior(b);
     }
 
     /* behavior::call */
     object_ref call() const
     {
-      obj::small_integer i{ data };
+      obj::small_integer const i{ data };
       return i.call();
     }
 
     object_ref call(object_ref const a1) const
     {
-      obj::small_integer i{ data };
+      obj::small_integer const i{ data };
       return i.call(a1);
     }
 
     object_ref call(object_ref const a1, object_ref const a2) const
     {
-      obj::small_integer i{ data };
+      obj::small_integer const i{ data };
       return i.call(a1, a2);
     }
 
     object_ref call(object_ref const a1, object_ref const a2, object_ref const a3) const
     {
-      obj::small_integer i{ data };
+      obj::small_integer const i{ data };
       return i.call(a1, a2, a3);
     }
 
     object_ref
     call(object_ref const a1, object_ref const a2, object_ref const a3, object_ref const a4) const
     {
-      obj::small_integer i{ data };
+      obj::small_integer const i{ data };
       return i.call(a1, a2, a3, a4);
     }
 
@@ -1188,7 +1191,7 @@ namespace jank::runtime
                     object_ref const a4,
                     object_ref const a5) const
     {
-      obj::small_integer i{ data };
+      obj::small_integer const i{ data };
       return i.call(a1, a2, a3, a4, a5);
     }
 
@@ -1199,7 +1202,7 @@ namespace jank::runtime
                     object_ref const a5,
                     object_ref const a6) const
     {
-      obj::small_integer i{ data };
+      obj::small_integer const i{ data };
       return i.call(a1, a2, a3, a4, a5, a6);
     }
 
@@ -1211,7 +1214,7 @@ namespace jank::runtime
                     object_ref const a6,
                     object_ref const a7) const
     {
-      obj::small_integer i{ data };
+      obj::small_integer const i{ data };
       return i.call(a1, a2, a3, a4, a5, a6, a7);
     }
 
@@ -1224,7 +1227,7 @@ namespace jank::runtime
                     object_ref const a7,
                     object_ref const a8) const
     {
-      obj::small_integer i{ data };
+      obj::small_integer const i{ data };
       return i.call(a1, a2, a3, a4, a5, a6, a7, a8);
     }
 
@@ -1238,7 +1241,7 @@ namespace jank::runtime
                     object_ref const a8,
                     object_ref const a9) const
     {
-      obj::small_integer i{ data };
+      obj::small_integer const i{ data };
       return i.call(a1, a2, a3, a4, a5, a6, a7, a8, a9);
     }
 
@@ -1253,7 +1256,7 @@ namespace jank::runtime
                     object_ref const a9,
                     object_ref const a10) const
     {
-      obj::small_integer i{ data };
+      obj::small_integer const i{ data };
       return i.call(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10);
     }
 
@@ -1265,26 +1268,26 @@ namespace jank::runtime
     /* behavior::get */
     object_ref get(object_ref const key) const
     {
-      obj::small_integer i{ data };
+      obj::small_integer const i{ data };
       return i.get(key);
     }
 
     object_ref get(object_ref const key, object_ref const fallback) const
     {
-      obj::small_integer i{ data };
+      obj::small_integer const i{ data };
       return i.get(key, fallback);
     }
 
     bool contains(object_ref const key) const
     {
-      obj::small_integer i{ data };
+      obj::small_integer const i{ data };
       return i.contains(key);
     }
 
     /* behavior::find */
     object_ref find(object_ref key) const
     {
-      obj::small_integer i{ data };
+      obj::small_integer const i{ data };
       return i.find(key);
     }
 
@@ -1298,7 +1301,7 @@ namespace jank::runtime
         return (r < l) - (l < r);
       }
 
-      obj::small_integer i{ data };
+      obj::small_integer const i{ data };
       return i.compare(*o.data);
     }
 
@@ -1310,7 +1313,7 @@ namespace jank::runtime
 
     f64 to_real() const
     {
-      return data;
+      return static_cast<f64>(data);
     }
 
     i64 data{};
@@ -1594,7 +1597,7 @@ namespace jank::runtime
     {
       if(detail::is_small_int(o.data))
       {
-        obj::small_integer i{ detail::as_int(o.data) };
+        obj::small_integer const i{ detail::as_int(o.data) };
         return _jank_nil.compare(i);
       }
       return _jank_nil.compare(*o.data);

--- a/compiler+runtime/include/cpp/jank/runtime/oref.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/oref.hpp
@@ -8,6 +8,8 @@
 #include <jtl/assert.hpp>
 
 #include <jank/runtime/object.hpp>
+#include <jank/runtime/obj/nil.hpp>
+#include <jank/runtime/obj/number.hpp>
 
 /* During AOT codegen, we need to initialize a bunch of lifted constants and globals, but
  * the jank_nil global may not yet be initialized, since the order of initialization of globals
@@ -24,14 +26,42 @@ namespace jank::runtime
   namespace obj
   {
     struct nil;
-    struct boolean;
+
+    using boolean_ref = oref<boolean>;
+    using integer_ref = oref<integer>;
+    using small_integer_ref = oref<small_integer>;
+    using real_ref = oref<real>;
   }
 
-  extern jank::runtime::obj::nil const _jank_nil;
   /* NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables) */
   extern oref<struct obj::boolean> jank_true;
   /* NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables) */
   extern oref<struct obj::boolean> jank_false;
+
+  namespace detail
+  {
+    constexpr char integer_tag{ 0b1 };
+    constexpr char integer_tag_mask{ 0b1 };
+    constexpr char integer_shift{ 1 };
+    constexpr i64 max_small_integer{ std::numeric_limits<i64>::max() & ~(1ll << 63) };
+
+    inline bool is_small_int(void const *data)
+    {
+      return (reinterpret_cast<int64_t>(data) & integer_tag_mask) == integer_tag;
+    }
+
+    inline i64 as_int(void const *data)
+    {
+      /* NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions, bugprone-narrowing-conversions) */
+      return reinterpret_cast<i64>(data) >> integer_shift;
+    }
+
+    template <typename T>
+    T as_ptr(i64 const data)
+    {
+      return reinterpret_cast<T>((static_cast<u64>(data) << integer_shift) | integer_tag_mask);
+    }
+  }
 
   template <typename T>
   struct oref;
@@ -44,6 +74,7 @@ namespace jank::runtime
   struct oref<O>
   {
     using value_type = object;
+    using object_ref = oref<O>;
 
     oref() = default;
     oref(oref const &rhs) = default;
@@ -92,9 +123,16 @@ namespace jank::runtime
     }
 
     template <typename T>
-    requires behavior::object_like<T>
+    requires(behavior::object_like<T> && !jtl::is_same<T, obj::small_integer>)
     oref(oref<T> const &typed_data) noexcept
       : data{ typed_data.erase().data }
+    {
+    }
+
+    template <typename T>
+    requires(jtl::is_same<T, obj::small_integer>)
+    oref(oref<T> const &typed_data) noexcept
+      : data{ detail::as_ptr<object *>(typed_data.data) }
     {
     }
 
@@ -115,17 +153,33 @@ namespace jank::runtime
       data = o.data;
     }
 
-    value_type *operator->() const noexcept
-    {
-      jank_assert(data);
-      return data;
-    }
+    //value_type *operator->() const noexcept
+    //{
+    //  jank_assert(data);
 
-    value_type &operator*() const noexcept
-    {
-      jank_assert(data);
-      return *data;
-    }
+    //  if(detail::is_small_int(data))
+    //  {
+    //    static obj::integer scratch{ 0 };
+    //    scratch.data = detail::as_int(data);
+    //    return &scratch;
+    //  }
+
+    //  return data;
+    //}
+
+    //value_type &operator*() const noexcept
+    //{
+    //  jank_assert(data);
+
+    //  if(detail::is_small_int(data))
+    //  {
+    //    static obj::integer scratch{ 0 };
+    //    scratch.data = detail::as_int(data);
+    //    return scratch;
+    //  }
+
+    //  return *data;
+    //}
 
     oref &operator=(oref const &rhs) noexcept = default;
     oref &operator=(oref &&rhs) noexcept = default;
@@ -171,25 +225,349 @@ namespace jank::runtime
     bool operator==(jtl::nullptr_t) noexcept = delete;
     bool operator!=(jtl::nullptr_t) noexcept = delete;
 
-    value_type *get() const noexcept
-    {
-      return data;
-    }
+    /* TODO: Remove this. */
+    //value_type *get() const noexcept
+    //{
+    //  if(detail::is_small_int(data))
+    //  {
+    //    static obj::integer scratch{ 0 };
+    //    scratch.data = detail::as_int(data);
+    //    return &scratch;
+    //  }
 
-    oref<object> const &erase() const noexcept
+    //  return data;
+    //}
+
+    object_ref const &erase() const noexcept
     {
       return *this;
     }
 
     bool is_some() const noexcept
     {
+      if(detail::is_small_int(data))
+      {
+        return true;
+      }
+
       /* NOLINTNEXTLINE(clang-analyzer-core.NullDereference): I cannot see how this can happen. We initialize to non-null and always ensure non-null on mutation. That's the whole point of this type. */
       return data->type != object_type::nil;
     }
 
     bool is_nil() const noexcept
     {
+      if(detail::is_small_int(data))
+      {
+        return false;
+      }
+
       return data->type == object_type::nil;
+    }
+
+    /* object_like */
+    object_type get_type() const
+    {
+      if(detail::is_small_int(data))
+      {
+        return object_type::small_integer;
+      }
+      return data->type;
+    }
+
+    bool equal(object_ref const o) const
+    {
+      if(detail::is_small_int(data))
+      {
+        if(detail::is_small_int(o.data))
+        {
+          return detail::as_int(data) == detail::as_int(o.data);
+        }
+
+        obj::small_integer i{ detail::as_int(data) };
+        return o.equal(&i);
+      }
+      else if(detail::is_small_int(o.data))
+      {
+        obj::small_integer i{ detail::as_int(o.data) };
+        return data->equal(i);
+      }
+      return data->equal(*o.data);
+    }
+
+    jtl::immutable_string to_string() const
+    {
+      if(detail::is_small_int(data))
+      {
+        obj::small_integer i{ detail::as_int(data) };
+        return i.to_string();
+      }
+      return data->to_string();
+    }
+
+    void to_string(jtl::string_builder &sb) const
+    {
+      if(detail::is_small_int(data))
+      {
+        obj::small_integer i{ detail::as_int(data) };
+        i.to_string(sb);
+        return;
+      }
+      data->to_string(sb);
+    }
+
+    jtl::immutable_string to_code_string() const
+    {
+      if(detail::is_small_int(data))
+      {
+        obj::small_integer i{ detail::as_int(data) };
+        return i.to_code_string();
+      }
+      return data->to_code_string();
+    }
+
+    uhash to_hash() const
+    {
+      if(detail::is_small_int(data))
+      {
+        obj::small_integer i{ detail::as_int(data) };
+        return i.to_hash();
+      }
+      return data->to_hash();
+    }
+
+    bool has_behavior(object_behavior const b) const
+    {
+      if(detail::is_small_int(data))
+      {
+        obj::small_integer i{ detail::as_int(data) };
+        return i.has_behavior(b);
+      }
+      return data->has_behavior(b);
+    }
+
+    /* behavior::call */
+    object_ref call() const
+    {
+      if(detail::is_small_int(data))
+      {
+        /* TODO */
+        return &_jank_nil;
+      }
+      return data->call();
+    }
+
+    object_ref call(object_ref const a1) const
+    {
+      if(detail::is_small_int(data))
+      {
+        /* TODO */
+        return &_jank_nil;
+      }
+      return data->call(a1);
+    }
+
+    object_ref call(object_ref const a1, object_ref const a2) const
+    {
+      if(detail::is_small_int(data))
+      {
+        /* TODO */
+        return &_jank_nil;
+      }
+      return data->call(a1, a2);
+    }
+
+    object_ref call(object_ref const a1, object_ref const a2, object_ref const a3) const
+    {
+      if(detail::is_small_int(data))
+      {
+        /* TODO */
+        return &_jank_nil;
+      }
+      return data->call(a1, a2, a3);
+    }
+
+    object_ref
+    call(object_ref const a1, object_ref const a2, object_ref const a3, object_ref const a4) const
+    {
+      if(detail::is_small_int(data))
+      {
+        /* TODO */
+        return &_jank_nil;
+      }
+      return data->call(a1, a2, a3, a4);
+    }
+
+    object_ref call(object_ref const a1,
+                    object_ref const a2,
+                    object_ref const a3,
+                    object_ref const a4,
+                    object_ref const a5) const
+    {
+      if(detail::is_small_int(data))
+      {
+        /* TODO */
+        return &_jank_nil;
+      }
+      return data->call(a1, a2, a3, a4, a5);
+    }
+
+    object_ref call(object_ref const a1,
+                    object_ref const a2,
+                    object_ref const a3,
+                    object_ref const a4,
+                    object_ref const a5,
+                    object_ref const a6) const
+    {
+      if(detail::is_small_int(data))
+      {
+        /* TODO */
+        return &_jank_nil;
+      }
+      return data->call(a1, a2, a3, a4, a5, a6);
+    }
+
+    object_ref call(object_ref const a1,
+                    object_ref const a2,
+                    object_ref const a3,
+                    object_ref const a4,
+                    object_ref const a5,
+                    object_ref const a6,
+                    object_ref const a7) const
+    {
+      if(detail::is_small_int(data))
+      {
+        /* TODO */
+        return &_jank_nil;
+      }
+      return data->call(a1, a2, a3, a4, a5, a6, a7);
+    }
+
+    object_ref call(object_ref const a1,
+                    object_ref const a2,
+                    object_ref const a3,
+                    object_ref const a4,
+                    object_ref const a5,
+                    object_ref const a6,
+                    object_ref const a7,
+                    object_ref const a8) const
+    {
+      if(detail::is_small_int(data))
+      {
+        /* TODO */
+        return &_jank_nil;
+      }
+      return data->call(a1, a2, a3, a4, a5, a6, a7, a8);
+    }
+
+    object_ref call(object_ref const a1,
+                    object_ref const a2,
+                    object_ref const a3,
+                    object_ref const a4,
+                    object_ref const a5,
+                    object_ref const a6,
+                    object_ref const a7,
+                    object_ref const a8,
+                    object_ref const a9) const
+    {
+      if(detail::is_small_int(data))
+      {
+        /* TODO */
+        return &_jank_nil;
+      }
+      return data->call(a1, a2, a3, a4, a5, a6, a7, a8, a9);
+    }
+
+    object_ref call(object_ref const a1,
+                    object_ref const a2,
+                    object_ref const a3,
+                    object_ref const a4,
+                    object_ref const a5,
+                    object_ref const a6,
+                    object_ref const a7,
+                    object_ref const a8,
+                    object_ref const a9,
+                    object_ref const a10) const
+    {
+      if(detail::is_small_int(data))
+      {
+        /* TODO */
+        return &_jank_nil;
+      }
+      return data->call(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10);
+    }
+
+    callable_arity_flags get_arity_flags() const
+    {
+      if(detail::is_small_int(data))
+      {
+        return 0;
+      }
+      return data->get_arity_flags();
+    }
+
+    /* behavior::get */
+    object_ref get(object_ref const key) const
+    {
+      if(detail::is_small_int(data))
+      {
+        /* TODO */
+        return &_jank_nil;
+      }
+      return data->get(key);
+    }
+
+    object_ref get(object_ref const key, object_ref const fallback) const
+    {
+      if(detail::is_small_int(data))
+      {
+        /* TODO */
+        return &_jank_nil;
+      }
+      return data->get(key, fallback);
+    }
+
+    bool contains(object_ref const key) const
+    {
+      if(detail::is_small_int(data))
+      {
+        /* TODO */
+        return false;
+      }
+      return data->contains(key);
+    }
+
+    /* behavior::find */
+    object_ref find(object_ref key) const
+    {
+      if(detail::is_small_int(data))
+      {
+        /* TODO */
+        return &_jank_nil;
+      }
+      return data->find(key);
+    }
+
+    /* behavior::compare */
+    i64 compare(object_ref const o) const
+    {
+      if(detail::is_small_int(data))
+      {
+        if(detail::is_small_int(o.data))
+        {
+          auto const l{ detail::as_int(data) };
+          auto const r{ detail::as_int(o.data) };
+          return (r < l) - (l < r);
+        }
+
+        obj::small_integer i{ detail::as_int(data) };
+        return o.compare(&i);
+      }
+      else if(detail::is_small_int(o.data))
+      {
+        obj::small_integer i{ detail::as_int(o.data) };
+        return data->compare(i);
+      }
+      return data->compare(*o.data);
     }
 
     value_type *data{ std::bit_cast<object *>(&_jank_nil) };
@@ -280,6 +658,10 @@ namespace jank::runtime
       /* TODO: Add type name. */
       //jank_assert_fmt(*this, "Null reference on oref<{}>", jtl::type_name<T>());
       jank_assert(is_some());
+
+      static_assert(!jtl::is_same<T, obj::small_integer>,
+                    "operator-> is not supported for small_integer_ref");
+
       return reinterpret_cast<T *>(data);
     }
 
@@ -287,6 +669,10 @@ namespace jank::runtime
     {
       //jank_assert_fmt(*this, "Null reference on oref<{}>", jtl::type_name<T>());
       jank_assert(is_some());
+
+      static_assert(!jtl::is_same<T, obj::small_integer>,
+                    "operator* is not supported for small_integer_ref");
+
       return *reinterpret_cast<T *>(data);
     }
 
@@ -382,7 +768,567 @@ namespace jank::runtime
       return data == std::bit_cast<void *>(&_jank_nil);
     }
 
+    /* object_like */
+    object_type get_type() const
+    {
+      if(is_nil())
+      {
+        return object_type::nil;
+      }
+      return static_cast<T *>(data)->type;
+    }
+
+    bool equal(object_ref const o) const
+    {
+      if(is_nil())
+      {
+        return o.is_nil();
+      }
+      if(detail::is_small_int(o.data))
+      {
+        obj::small_integer i{ detail::as_int(o.data) };
+        return static_cast<T *>(data)->equal(i);
+      }
+      return static_cast<T *>(data)->equal(*o.data);
+    }
+
+    jtl::immutable_string to_string() const
+    {
+      if(is_nil())
+      {
+        return _jank_nil.to_string();
+      }
+      return static_cast<T *>(data)->to_string();
+    }
+
+    void to_string(jtl::string_builder &sb) const
+    {
+      if(is_nil())
+      {
+        _jank_nil.to_string(sb);
+        return;
+      }
+      static_cast<T *>(data)->to_string(sb);
+    }
+
+    jtl::immutable_string to_code_string() const
+    {
+      if(is_nil())
+      {
+        return _jank_nil.to_code_string();
+      }
+      return static_cast<T *>(data)->to_code_string();
+    }
+
+    uhash to_hash() const
+    {
+      if(is_nil())
+      {
+        return _jank_nil.to_hash();
+      }
+      return static_cast<T *>(data)->to_hash();
+    }
+
+    bool has_behavior(object_behavior const b) const
+    {
+      if(is_nil())
+      {
+        return _jank_nil.has_behavior(b);
+      }
+      return static_cast<T *>(data)->has_behavior(b);
+    }
+
+    /* behavior::call */
+    object_ref call() const
+    {
+      if(is_nil())
+      {
+        return _jank_nil.call();
+      }
+      return static_cast<T *>(data)->call();
+    }
+
+    object_ref call(object_ref const a1) const
+    {
+      if(is_nil())
+      {
+        return _jank_nil.call(a1);
+      }
+      return static_cast<T *>(data)->call(a1);
+    }
+
+    object_ref call(object_ref const a1, object_ref const a2) const
+    {
+      if(is_nil())
+      {
+        return _jank_nil.call(a1, a2);
+      }
+      return static_cast<T *>(data)->call(a1, a2);
+    }
+
+    object_ref call(object_ref const a1, object_ref const a2, object_ref const a3) const
+    {
+      if(is_nil())
+      {
+        return _jank_nil.call(a1, a2, a3);
+      }
+      return static_cast<T *>(data)->call(a1, a2, a3);
+    }
+
+    object_ref
+    call(object_ref const a1, object_ref const a2, object_ref const a3, object_ref const a4) const
+    {
+      if(is_nil())
+      {
+        return _jank_nil.call(a1, a2, a3, a4);
+      }
+      return static_cast<T *>(data)->call(a1, a2, a3, a4);
+    }
+
+    object_ref call(object_ref const a1,
+                    object_ref const a2,
+                    object_ref const a3,
+                    object_ref const a4,
+                    object_ref const a5) const
+    {
+      if(is_nil())
+      {
+        return _jank_nil.call(a1, a2, a3, a4, a5);
+      }
+      return static_cast<T *>(data)->call(a1, a2, a3, a4, a5);
+    }
+
+    object_ref call(object_ref const a1,
+                    object_ref const a2,
+                    object_ref const a3,
+                    object_ref const a4,
+                    object_ref const a5,
+                    object_ref const a6) const
+    {
+      if(is_nil())
+      {
+        return _jank_nil.call(a1, a2, a3, a4, a5, a6);
+      }
+      return static_cast<T *>(data)->call(a1, a2, a3, a4, a5, a6);
+    }
+
+    object_ref call(object_ref const a1,
+                    object_ref const a2,
+                    object_ref const a3,
+                    object_ref const a4,
+                    object_ref const a5,
+                    object_ref const a6,
+                    object_ref const a7) const
+    {
+      if(is_nil())
+      {
+        return _jank_nil.call(a1, a2, a3, a4, a5, a6, a7);
+      }
+      return static_cast<T *>(data)->call(a1, a2, a3, a4, a5, a6, a7);
+    }
+
+    object_ref call(object_ref const a1,
+                    object_ref const a2,
+                    object_ref const a3,
+                    object_ref const a4,
+                    object_ref const a5,
+                    object_ref const a6,
+                    object_ref const a7,
+                    object_ref const a8) const
+    {
+      if(is_nil())
+      {
+        return _jank_nil.call(a1, a2, a3, a4, a5, a6, a7, a8);
+      }
+      return static_cast<T *>(data)->call(a1, a2, a3, a4, a5, a6, a7, a8);
+    }
+
+    object_ref call(object_ref const a1,
+                    object_ref const a2,
+                    object_ref const a3,
+                    object_ref const a4,
+                    object_ref const a5,
+                    object_ref const a6,
+                    object_ref const a7,
+                    object_ref const a8,
+                    object_ref const a9) const
+    {
+      if(is_nil())
+      {
+        return _jank_nil.call(a1, a2, a3, a4, a5, a6, a7, a8, a9);
+      }
+      return static_cast<T *>(data)->call(a1, a2, a3, a4, a5, a6, a7, a8, a9);
+    }
+
+    object_ref call(object_ref const a1,
+                    object_ref const a2,
+                    object_ref const a3,
+                    object_ref const a4,
+                    object_ref const a5,
+                    object_ref const a6,
+                    object_ref const a7,
+                    object_ref const a8,
+                    object_ref const a9,
+                    object_ref const a10) const
+    {
+      if(is_nil())
+      {
+        return _jank_nil.call(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10);
+      }
+      return static_cast<T *>(data)->call(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10);
+    }
+
+    callable_arity_flags get_arity_flags() const
+    {
+      if(is_nil())
+      {
+        return _jank_nil.get_arity_flags();
+      }
+      return static_cast<T *>(data)->get_arity_flags();
+    }
+
+    /* behavior::get */
+    object_ref get(object_ref const key) const
+    {
+      if(is_nil())
+      {
+        return _jank_nil.get(key);
+      }
+      return static_cast<T *>(data)->get(key);
+    }
+
+    object_ref get(object_ref const key, object_ref const fallback) const
+    {
+      if(is_nil())
+      {
+        return _jank_nil.get(key, fallback);
+      }
+      return static_cast<T *>(data)->get(key, fallback);
+    }
+
+    bool contains(object_ref const key) const
+    {
+      if(is_nil())
+      {
+        return _jank_nil.contains(key);
+      }
+      return static_cast<T *>(data)->contains(key);
+    }
+
+    /* behavior::find */
+    object_ref find(object_ref key) const
+    {
+      if(is_nil())
+      {
+        return _jank_nil.find(key);
+      }
+      return static_cast<T *>(data)->find(key);
+    }
+
+    /* behavior::compare */
+    i64 compare(object_ref const o) const
+    {
+      /* TODO: Handle o being small int. */
+      if(is_nil())
+      {
+        return _jank_nil.compare(*o.data);
+      }
+      return static_cast<T *>(data)->compare(*o.data);
+    }
+
     void *data{ std::bit_cast<void *>(&_jank_nil) };
+  };
+
+  template <>
+  struct oref<obj::small_integer>
+  {
+    using T = obj::small_integer;
+    using value_type = T;
+
+    oref() = default;
+    oref(oref const &rhs) noexcept = default;
+    oref(oref &&rhs) noexcept = default;
+
+    oref(nullptr_t) = delete;
+
+    oref(_jank_null) noexcept
+      : data{}
+    {
+    }
+
+    oref(void * const data) noexcept
+      : data{ detail::as_int(data) }
+    {
+    }
+
+    oref(i64 const data) noexcept
+      : data{ data }
+    {
+    }
+
+    ~oref() = default;
+
+    bool operator==(oref<object> const &rhs) const
+    {
+      if(detail::is_small_int(rhs.data))
+      {
+        return data == detail::as_int(rhs.data);
+      }
+      return false;
+    }
+
+    bool operator!=(oref<object> const &rhs) const
+    {
+      if(detail::is_small_int(rhs.data))
+      {
+        return data != detail::as_int(rhs.data);
+      }
+      return true;
+    }
+
+    oref &operator=(oref const &rhs) noexcept = default;
+    oref &operator=(oref &&rhs) noexcept = default;
+
+    oref &operator=(jtl::nullptr_t) noexcept = delete;
+    bool operator==(jtl::nullptr_t) noexcept = delete;
+    bool operator!=(jtl::nullptr_t) noexcept = delete;
+
+    oref<object> erase() const noexcept
+    {
+      return detail::as_ptr<object *>(data);
+    }
+
+    bool is_some() const noexcept
+    {
+      return true;
+    }
+
+    bool is_nil() const noexcept
+    {
+      return false;
+    }
+
+    oref const *operator->() const noexcept
+    {
+      return this;
+    }
+
+    oref const &operator*() const noexcept
+    {
+      return *this;
+    }
+
+    /* object_like */
+    object_type get_type() const
+    {
+      return object_type::small_integer;
+    }
+
+    bool equal(object_ref const o) const
+    {
+      if(detail::is_small_int(o.data))
+      {
+        return data == detail::as_int(o.data);
+      }
+
+      obj::small_integer i{ data };
+      return o.equal(&i);
+    }
+
+    jtl::immutable_string to_string() const
+    {
+      obj::small_integer i{ data };
+      return i.to_string();
+    }
+
+    void to_string(jtl::string_builder &sb) const
+    {
+      obj::small_integer i{ data };
+      i.to_string(sb);
+    }
+
+    jtl::immutable_string to_code_string() const
+    {
+      obj::small_integer i{ data };
+      return i.to_code_string();
+    }
+
+    uhash to_hash() const
+    {
+      obj::small_integer i{ data };
+      return i.to_hash();
+    }
+
+    bool has_behavior(object_behavior const b) const
+    {
+      obj::small_integer i{ data };
+      return i.has_behavior(b);
+    }
+
+    /* behavior::call */
+    object_ref call() const
+    {
+      obj::small_integer i{ data };
+      return i.call();
+    }
+
+    object_ref call(object_ref const a1) const
+    {
+      obj::small_integer i{ data };
+      return i.call(a1);
+    }
+
+    object_ref call(object_ref const a1, object_ref const a2) const
+    {
+      obj::small_integer i{ data };
+      return i.call(a1, a2);
+    }
+
+    object_ref call(object_ref const a1, object_ref const a2, object_ref const a3) const
+    {
+      obj::small_integer i{ data };
+      return i.call(a1, a2, a3);
+    }
+
+    object_ref
+    call(object_ref const a1, object_ref const a2, object_ref const a3, object_ref const a4) const
+    {
+      obj::small_integer i{ data };
+      return i.call(a1, a2, a3, a4);
+    }
+
+    object_ref call(object_ref const a1,
+                    object_ref const a2,
+                    object_ref const a3,
+                    object_ref const a4,
+                    object_ref const a5) const
+    {
+      obj::small_integer i{ data };
+      return i.call(a1, a2, a3, a4, a5);
+    }
+
+    object_ref call(object_ref const a1,
+                    object_ref const a2,
+                    object_ref const a3,
+                    object_ref const a4,
+                    object_ref const a5,
+                    object_ref const a6) const
+    {
+      obj::small_integer i{ data };
+      return i.call(a1, a2, a3, a4, a5, a6);
+    }
+
+    object_ref call(object_ref const a1,
+                    object_ref const a2,
+                    object_ref const a3,
+                    object_ref const a4,
+                    object_ref const a5,
+                    object_ref const a6,
+                    object_ref const a7) const
+    {
+      obj::small_integer i{ data };
+      return i.call(a1, a2, a3, a4, a5, a6, a7);
+    }
+
+    object_ref call(object_ref const a1,
+                    object_ref const a2,
+                    object_ref const a3,
+                    object_ref const a4,
+                    object_ref const a5,
+                    object_ref const a6,
+                    object_ref const a7,
+                    object_ref const a8) const
+    {
+      obj::small_integer i{ data };
+      return i.call(a1, a2, a3, a4, a5, a6, a7, a8);
+    }
+
+    object_ref call(object_ref const a1,
+                    object_ref const a2,
+                    object_ref const a3,
+                    object_ref const a4,
+                    object_ref const a5,
+                    object_ref const a6,
+                    object_ref const a7,
+                    object_ref const a8,
+                    object_ref const a9) const
+    {
+      obj::small_integer i{ data };
+      return i.call(a1, a2, a3, a4, a5, a6, a7, a8, a9);
+    }
+
+    object_ref call(object_ref const a1,
+                    object_ref const a2,
+                    object_ref const a3,
+                    object_ref const a4,
+                    object_ref const a5,
+                    object_ref const a6,
+                    object_ref const a7,
+                    object_ref const a8,
+                    object_ref const a9,
+                    object_ref const a10) const
+    {
+      obj::small_integer i{ data };
+      return i.call(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10);
+    }
+
+    callable_arity_flags get_arity_flags() const
+    {
+      return 0;
+    }
+
+    /* behavior::get */
+    object_ref get(object_ref const key) const
+    {
+      obj::small_integer i{ data };
+      return i.get(key);
+    }
+
+    object_ref get(object_ref const key, object_ref const fallback) const
+    {
+      obj::small_integer i{ data };
+      return i.get(key, fallback);
+    }
+
+    bool contains(object_ref const key) const
+    {
+      obj::small_integer i{ data };
+      return i.contains(key);
+    }
+
+    /* behavior::find */
+    object_ref find(object_ref key) const
+    {
+      obj::small_integer i{ data };
+      return i.find(key);
+    }
+
+    /* behavior::compare */
+    i64 compare(object_ref const o) const
+    {
+      if(detail::is_small_int(o.data))
+      {
+        auto const l{ data };
+        auto const r{ detail::as_int(o.data) };
+        return (r < l) - (l < r);
+      }
+
+      obj::small_integer i{ data };
+      return i.compare(*o.data);
+    }
+
+    /* behavior::number_like */
+    i64 to_integer() const
+    {
+      return data;
+    }
+
+    f64 to_real() const
+    {
+      return data;
+    }
+
+    i64 data{};
   };
 
   template <>
@@ -497,6 +1443,176 @@ namespace jank::runtime
     bool is_nil() const noexcept
     {
       return true;
+    }
+
+    /* object_like */
+    object_type get_type() const
+    {
+      return object_type::nil;
+    }
+
+    bool equal(object_ref const o) const
+    {
+      return o.is_nil();
+    }
+
+    jtl::immutable_string to_string() const
+    {
+      return _jank_nil.to_string();
+    }
+
+    void to_string(jtl::string_builder &sb) const
+    {
+      _jank_nil.to_string(sb);
+    }
+
+    jtl::immutable_string to_code_string() const
+    {
+      return _jank_nil.to_code_string();
+    }
+
+    uhash to_hash() const
+    {
+      return _jank_nil.to_hash();
+    }
+
+    bool has_behavior(object_behavior const b) const
+    {
+      return _jank_nil.has_behavior(b);
+    }
+
+    /* behavior::call */
+    object_ref call() const
+    {
+      return _jank_nil.call();
+    }
+
+    object_ref call(object_ref const a1) const
+    {
+      return _jank_nil.call(a1);
+    }
+
+    object_ref call(object_ref const a1, object_ref const a2) const
+    {
+      return _jank_nil.call(a1, a2);
+    }
+
+    object_ref call(object_ref const a1, object_ref const a2, object_ref const a3) const
+    {
+      return _jank_nil.call(a1, a2, a3);
+    }
+
+    object_ref
+    call(object_ref const a1, object_ref const a2, object_ref const a3, object_ref const a4) const
+    {
+      return _jank_nil.call(a1, a2, a3, a4);
+    }
+
+    object_ref call(object_ref const a1,
+                    object_ref const a2,
+                    object_ref const a3,
+                    object_ref const a4,
+                    object_ref const a5) const
+    {
+      return _jank_nil.call(a1, a2, a3, a4, a5);
+    }
+
+    object_ref call(object_ref const a1,
+                    object_ref const a2,
+                    object_ref const a3,
+                    object_ref const a4,
+                    object_ref const a5,
+                    object_ref const a6) const
+    {
+      return _jank_nil.call(a1, a2, a3, a4, a5, a6);
+    }
+
+    object_ref call(object_ref const a1,
+                    object_ref const a2,
+                    object_ref const a3,
+                    object_ref const a4,
+                    object_ref const a5,
+                    object_ref const a6,
+                    object_ref const a7) const
+    {
+      return _jank_nil.call(a1, a2, a3, a4, a5, a6, a7);
+    }
+
+    object_ref call(object_ref const a1,
+                    object_ref const a2,
+                    object_ref const a3,
+                    object_ref const a4,
+                    object_ref const a5,
+                    object_ref const a6,
+                    object_ref const a7,
+                    object_ref const a8) const
+    {
+      return _jank_nil.call(a1, a2, a3, a4, a5, a6, a7, a8);
+    }
+
+    object_ref call(object_ref const a1,
+                    object_ref const a2,
+                    object_ref const a3,
+                    object_ref const a4,
+                    object_ref const a5,
+                    object_ref const a6,
+                    object_ref const a7,
+                    object_ref const a8,
+                    object_ref const a9) const
+    {
+      return _jank_nil.call(a1, a2, a3, a4, a5, a6, a7, a8, a9);
+    }
+
+    object_ref call(object_ref const a1,
+                    object_ref const a2,
+                    object_ref const a3,
+                    object_ref const a4,
+                    object_ref const a5,
+                    object_ref const a6,
+                    object_ref const a7,
+                    object_ref const a8,
+                    object_ref const a9,
+                    object_ref const a10) const
+    {
+      return _jank_nil.call(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10);
+    }
+
+    callable_arity_flags get_arity_flags() const
+    {
+      return _jank_nil.get_arity_flags();
+    }
+
+    /* behavior::get */
+    object_ref get(object_ref const key) const
+    {
+      return _jank_nil.get(key);
+    }
+
+    object_ref get(object_ref const key, object_ref const fallback) const
+    {
+      return _jank_nil.get(key, fallback);
+    }
+
+    bool contains(object_ref const key) const
+    {
+      return _jank_nil.contains(key);
+    }
+
+    /* behavior::find */
+    object_ref find(object_ref key) const
+    {
+      return _jank_nil.find(key);
+    }
+
+    /* behavior::compare */
+    i64 compare(object_ref const o) const
+    {
+      if(detail::is_small_int(o.data))
+      {
+        obj::small_integer i{ detail::as_int(o.data) };
+        return _jank_nil.compare(i);
+      }
+      return _jank_nil.compare(*o.data);
     }
 
     value_type *data{ std::bit_cast<value_type *>(&_jank_nil) };

--- a/compiler+runtime/include/cpp/jank/runtime/oref.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/oref.hpp
@@ -43,7 +43,8 @@ namespace jank::runtime
     constexpr char integer_tag{ 0b1 };
     constexpr char integer_tag_mask{ 0b1 };
     constexpr char integer_shift{ 1 };
-    constexpr i64 max_small_integer{ std::numeric_limits<i64>::max() & ~(1ll << 63) };
+    constexpr i64 max_small_integer{ std::numeric_limits<i64>::max() >> integer_shift };
+    constexpr i64 min_small_integer{ std::numeric_limits<i64>::min() >> integer_shift };
 
     inline bool is_small_int(void const *data)
     {
@@ -59,7 +60,7 @@ namespace jank::runtime
     template <typename T>
     T as_ptr(i64 const data)
     {
-      return reinterpret_cast<T>((static_cast<u64>(data) << integer_shift) | integer_tag_mask);
+      return reinterpret_cast<T>((data << integer_shift) | integer_tag_mask);
     }
   }
 

--- a/compiler+runtime/include/cpp/jank/runtime/oref.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/oref.hpp
@@ -38,6 +38,31 @@ namespace jank::runtime
   /* NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables) */
   extern oref<struct obj::boolean> jank_false;
 
+  /* `oref` is jank's pointer wrapper for boxed runtime objects. It is only used for objects
+   * which inherit from `jank::runtime::object` and implement the necessary behaviors. It's
+   * formidable, though, since it serves a few very important roles in the jank runtime.
+   *
+   * 1. It provides a type-erased `object_ref`, which can represent any runtime object
+   *    (like Java's `Object`)
+   * 2. It provides typed refs, like `integer_ref`, `persistent_string_ref`, and so on, for
+   *    every runtime object type
+   * 3. It allows any of these refs to be `nil` and provides helpers for querying that
+   * 4. It supports inline values for certain tagged pointers
+   *
+   * To expand on the inline values and tagged pointers, `object_ref` (the type-erased `oref`)
+   * can either hold a pointer value or an inline integer. The integer is case indicated by the
+   * lowest bit of the pointer value being 1, in which case a 63 bit integer exists instead of
+   * a pointer value. This is an incredible performance win for integer-heavy jank programs, since
+   * it allows us to skip GC allocations for those integers. However, it means that we need to
+   * treat `object_ref` specially, since it isn't just a simple pointer wrapper.
+   *
+   * Similarly, there is a specialization of `oref` for `small_integer`, which simulates a pointer
+   * to a typed integral object like `integer_ref`, but it stores the integer value inline. This
+   * is used when we visit an `object_ref` which holds an inline integer and we need a fully typed
+   * object. */
+
+  /* TODO: Support inline doubles. */
+
   namespace detail
   {
     constexpr char integer_tag{ 0b1 };
@@ -154,34 +179,6 @@ namespace jank::runtime
       data = o.data;
     }
 
-    //value_type *operator->() const noexcept
-    //{
-    //  jank_assert(data);
-
-    //  if(detail::is_small_int(data))
-    //  {
-    //    static obj::integer scratch{ 0 };
-    //    scratch.data = detail::as_int(data);
-    //    return &scratch;
-    //  }
-
-    //  return data;
-    //}
-
-    //value_type &operator*() const noexcept
-    //{
-    //  jank_assert(data);
-
-    //  if(detail::is_small_int(data))
-    //  {
-    //    static obj::integer scratch{ 0 };
-    //    scratch.data = detail::as_int(data);
-    //    return scratch;
-    //  }
-
-    //  return *data;
-    //}
-
     oref &operator=(oref const &rhs) noexcept = default;
     oref &operator=(oref &&rhs) noexcept = default;
 
@@ -225,19 +222,6 @@ namespace jank::runtime
     oref &operator=(jtl::nullptr_t) noexcept = delete;
     bool operator==(jtl::nullptr_t) noexcept = delete;
     bool operator!=(jtl::nullptr_t) noexcept = delete;
-
-    /* TODO: Remove this. */
-    //value_type *get() const noexcept
-    //{
-    //  if(detail::is_small_int(data))
-    //  {
-    //    static obj::integer scratch{ 0 };
-    //    scratch.data = detail::as_int(data);
-    //    return &scratch;
-    //  }
-
-    //  return data;
-    //}
 
     object_ref const &erase() const noexcept
     {

--- a/compiler+runtime/include/cpp/jank/runtime/rtti.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/rtti.hpp
@@ -18,7 +18,7 @@ namespace jank::runtime
   [[gnu::always_inline, gnu::flatten, gnu::hot]]
   constexpr oref<T> dyn_cast(object_ref const o)
   {
-    if(o->type != T::obj_type)
+    if(o.get_type() != T::obj_type)
     {
       return {};
     }
@@ -30,13 +30,13 @@ namespace jank::runtime
   [[gnu::always_inline, gnu::flatten, gnu::hot]]
   oref<T> try_object(object_ref const o)
   {
-    if(o->type != T::obj_type)
+    if(o.get_type() != T::obj_type)
     {
       jtl::string_builder sb;
       sb("invalid object type (expected ");
       sb(object_type_str(T::obj_type));
       sb(" found ");
-      sb(object_type_str(o->type));
+      sb(object_type_str(o.get_type()));
       sb(")");
       throw std::runtime_error{ sb.str() };
     }
@@ -57,17 +57,23 @@ namespace jank::runtime
     {
       jank_debug_assert(o.is_some());
     }
-    jank_debug_assert(o->type == T::obj_type);
+    jank_debug_assert(o.get_type() == T::obj_type);
+
     return static_cast<T *>(o.data);
   }
 
   template <typename T>
   requires behavior::object_like<T>
   [[gnu::always_inline, gnu::flatten, gnu::hot]]
-  constexpr oref<T> expect_object(object const * const o)
+  oref<T> expect_object(object const * const o)
   {
     jank_debug_assert(o);
     jank_debug_assert(o->type == T::obj_type);
+
     return static_cast<T *>(const_cast<object *>(o));
   }
+
+  /* TODO: Inline once we have LLVM 23. */
+  template <>
+  obj::small_integer_ref expect_object<obj::small_integer>(object const * const o);
 }

--- a/compiler+runtime/include/cpp/jank/runtime/visit.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/visit.hpp
@@ -85,7 +85,12 @@ namespace jank::runtime
   [[gnu::hot]]
   auto visit_object(F const &fn, object_ref const erased, Args &&...args)
   {
-    switch(erased->type)
+    if(detail::is_small_int(erased.data))
+    {
+      return fn(obj::small_integer_ref{ erased.data }, std::forward<Args>(args)...);
+    }
+
+    switch(erased.get_type())
     {
       case object_type::nil:
         return fn(expect_object<obj::nil>(erased), std::forward<Args>(args)...);
@@ -93,6 +98,8 @@ namespace jank::runtime
         return fn(expect_object<obj::boolean>(erased), std::forward<Args>(args)...);
       case object_type::integer:
         return fn(expect_object<obj::integer>(erased), std::forward<Args>(args)...);
+      case object_type::small_integer:
+        return fn(expect_object<obj::small_integer>(erased), std::forward<Args>(args)...);
       case object_type::big_integer:
         return fn(expect_object<obj::big_integer>(erased), std::forward<Args>(args)...);
       case object_type::big_decimal:
@@ -224,8 +231,8 @@ namespace jank::runtime
         return fn(expect_object<obj::reader_conditional>(erased), std::forward<Args>(args)...);
       default:
         jtl::panic("invalid object type: {}, raw value {}",
-                   object_type_str(erased->type),
-                   static_cast<int>(erased->type));
+                   object_type_str(erased.get_type()),
+                   static_cast<int>(erased.get_type()));
     }
   }
 
@@ -234,15 +241,22 @@ namespace jank::runtime
   [[gnu::hot]]
   auto visit_type(F const &fn, object_ref const erased, Args &&...args)
   {
-    if(erased->type == T::obj_type)
+    if(erased.get_type() == T::obj_type)
     {
+      if constexpr(jtl::is_same<T, obj::integer>)
+      {
+        if(detail::is_small_int(erased.data))
+        {
+          return fn(obj::small_integer_ref{ erased.data }, std::forward<Args>(args)...);
+        }
+      }
       return fn(expect_object<T>(erased), std::forward<Args>(args)...);
     }
     else
     {
       jtl::panic("invalid object type: {}, raw value {}",
-                 object_type_str(erased->type),
-                 static_cast<int>(erased->type));
+                 object_type_str(erased.get_type()),
+                 static_cast<int>(erased.get_type()));
     }
   }
 
@@ -253,7 +267,7 @@ namespace jank::runtime
   {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wswitch-enum"
-    switch(erased->type)
+    switch(erased.get_type())
     {
       case object_type::nil:
         return fn(expect_object<obj::nil>(erased), std::forward<Args>(args)...);
@@ -345,7 +359,7 @@ namespace jank::runtime
   {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wswitch-enum"
-    switch(erased->type)
+    switch(erased.get_type())
     {
       case object_type::persistent_array_map:
         return fn(expect_object<obj::persistent_array_map>(erased), std::forward<Args>(args)...);
@@ -381,7 +395,7 @@ namespace jank::runtime
   {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wswitch-enum"
-    switch(erased->type)
+    switch(erased.get_type())
     {
       case object_type::persistent_hash_set:
         return fn(expect_object<obj::persistent_hash_set>(erased), std::forward<Args>(args)...);
@@ -413,12 +427,19 @@ namespace jank::runtime
   [[gnu::hot]]
   auto visit_number_like(F1 const &fn, F2 const &else_fn, object_ref const erased, Args &&...args)
   {
+    if(detail::is_small_int(erased.data))
+    {
+      return fn(obj::small_integer_ref{ erased.data }, std::forward<Args>(args)...);
+    }
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wswitch-enum"
-    switch(erased->type)
+    switch(erased.get_type())
     {
       case object_type::integer:
         return fn(expect_object<obj::integer>(erased), std::forward<Args>(args)...);
+      case object_type::small_integer:
+        return fn(expect_object<obj::small_integer>(erased), std::forward<Args>(args)...);
       case object_type::big_integer:
         return fn(expect_object<obj::big_integer>(erased), std::forward<Args>(args)...);
       case object_type::big_decimal:

--- a/compiler+runtime/include/cpp/jank/runtime/visit.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/visit.hpp
@@ -424,7 +424,7 @@ namespace jank::runtime
 
   template <typename F1, typename F2, typename... Args>
   requires(!std::convertible_to<F2, object_ref>)
-  [[gnu::hot]]
+  [[gnu::always_inline, gnu::flatten, gnu::hot]]
   auto visit_number_like(F1 const &fn, F2 const &else_fn, object_ref const erased, Args &&...args)
   {
     if(detail::is_small_int(erased.data))
@@ -456,7 +456,7 @@ namespace jank::runtime
 
   /* Throws if the object isn't number-like. */
   template <typename F1, typename... Args>
-  [[gnu::hot]]
+  [[gnu::always_inline, gnu::flatten, gnu::hot]]
   auto visit_number_like(F1 const &fn, object_ref const erased, Args &&...args)
   {
     return visit_number_like(

--- a/compiler+runtime/include/cpp/jtl/string_builder.hpp
+++ b/compiler+runtime/include/cpp/jtl/string_builder.hpp
@@ -4,6 +4,11 @@
 
 #include <jank/type.hpp>
 
+namespace jank::runtime::obj
+{
+  struct ratio_data;
+}
+
 namespace jtl
 {
   enum class terminal_style : u8;
@@ -36,6 +41,7 @@ namespace jtl
     string_builder &operator()(unsigned long d) &;
     string_builder &operator()(unsigned long long d) &;
     string_builder &operator()(jank::native_big_integer const &d) &;
+    string_builder &operator()(jank::runtime::obj::ratio_data const &r) &;
     string_builder &operator()(char d) &;
     string_builder &operator()(char32_t d) &;
     string_builder &operator()(char const *d) &;

--- a/compiler+runtime/src/cpp/clojure/core_native.cpp
+++ b/compiler+runtime/src/cpp/clojure/core_native.cpp
@@ -72,7 +72,7 @@ namespace clojure::core_native
 
   object_ref is_var(object_ref const o)
   {
-    return make_box(o->type == object_type::var);
+    return make_box(o.get_type() == object_type::var);
   }
 
   object_ref var_get(object_ref const o)
@@ -117,14 +117,15 @@ namespace clojure::core_native
 
   object_ref is_fn(object_ref const o)
   {
-    return make_box(o->type == object_type::native_function_wrapper
-                    || o->type == object_type::jit_function || o->type == object_type::jit_closure
-                    || o->type == object_type::deferred_cpp_function);
+    return make_box(o.get_type() == object_type::native_function_wrapper
+                    || o.get_type() == object_type::jit_function
+                    || o.get_type() == object_type::jit_closure
+                    || o.get_type() == object_type::deferred_cpp_function);
   }
 
   object_ref is_multi_fn(object_ref const o)
   {
-    return make_box(o->type == object_type::multi_function);
+    return make_box(o.get_type() == object_type::multi_function);
   }
 
   object_ref multi_fn(object_ref const name,
@@ -213,7 +214,7 @@ namespace clojure::core_native
 
   object_ref is_ns(object_ref const ns_or_sym)
   {
-    return make_box(ns_or_sym->type == object_type::ns);
+    return make_box(ns_or_sym.get_type() == object_type::ns);
   }
 
   object_ref ns_name(object_ref const ns)

--- a/compiler+runtime/src/cpp/clojure/string_native.cpp
+++ b/compiler+runtime/src/cpp/clojure/string_native.cpp
@@ -142,7 +142,7 @@ namespace clojure::string_native
   {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wswitch-enum"
-    switch(match->type)
+    switch(match.get_type())
     {
       case object_type::character:
         return replace_first(s,
@@ -153,7 +153,7 @@ namespace clojure::string_native
                              try_object<obj::persistent_string>(match)->data,
                              try_object<obj::persistent_string>(replacement)->data);
       case object_type::re_pattern:
-        if(replacement->type == object_type::persistent_string)
+        if(replacement.get_type() == object_type::persistent_string)
         {
           return replace_first(s,
                                try_object<obj::re_pattern>(match)->regex,
@@ -170,7 +170,7 @@ namespace clojure::string_native
 
   object_ref replace_first(object_ref const s, object_ref const match, object_ref const replacement)
   {
-    auto const is_string(s->type == object_type::persistent_string);
+    auto const is_string(s.get_type() == object_type::persistent_string);
     auto const &s_str(is_string ? try_object<obj::persistent_string>(s)->data
                                 : runtime::to_string(s));
 

--- a/compiler+runtime/src/cpp/jank/analyze/cpp_util.cpp
+++ b/compiler+runtime/src/cpp/jank/analyze/cpp_util.cpp
@@ -478,7 +478,7 @@ namespace jank::analyze::cpp_util
   {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wswitch-enum"
-    switch(o->type)
+    switch(o.get_type())
     {
       case jank::runtime::object_type::nil:
         {
@@ -496,6 +496,12 @@ namespace jank::analyze::cpp_util
         {
           static auto const type{ Cpp::GetTypeFromScope(
             resolve_scope("jank.runtime.obj.integer_ref").expect_ok()) };
+          return type;
+        }
+      case jank::runtime::object_type::small_integer:
+        {
+          static auto const type{ Cpp::GetTypeFromScope(
+            resolve_scope("jank.runtime.obj.small_integer_ref").expect_ok()) };
           return type;
         }
       case jank::runtime::object_type::character:

--- a/compiler+runtime/src/cpp/jank/analyze/expr/cpp_new.cpp
+++ b/compiler+runtime/src/cpp/jank/analyze/expr/cpp_new.cpp
@@ -1,10 +1,7 @@
+#include <CppInterOp/CppInterOp.h>
+
 #include <jank/analyze/expr/cpp_new.hpp>
 #include <jank/detail/to_runtime_data.hpp>
-
-namespace CppImpl
-{
-  void *GetPointerType(void *type);
-}
 
 namespace jank::analyze::expr
 {
@@ -40,6 +37,6 @@ namespace jank::analyze::expr
 
   jtl::ptr<void> cpp_new::get_type() const
   {
-    return CppImpl::GetPointerType(type);
+    return Cpp::GetPointerType(type);
   }
 }

--- a/compiler+runtime/src/cpp/jank/analyze/processor.cpp
+++ b/compiler+runtime/src/cpp/jank/analyze/processor.cpp
@@ -17,6 +17,7 @@
 #include <jank/runtime/core/make_box.hpp>
 #include <jank/runtime/core/seq.hpp>
 #include <jank/runtime/core/munge.hpp>
+#include <jank/runtime/core/math.hpp>
 #include <jank/runtime/sequence_range.hpp>
 #include <jank/analyze/processor.hpp>
 #include <jank/analyze/step/force_boxed.hpp>
@@ -1328,7 +1329,7 @@ namespace jank::analyze
     }
 
     auto const sym_obj(l->data.rest().first().unwrap());
-    if(sym_obj->type != runtime::object_type::symbol)
+    if(sym_obj.get_type() != runtime::object_type::symbol)
     {
       return error::analyze_invalid_def("The var name in a 'def' must be a symbol.",
                                         object_source(sym_obj),
@@ -1386,7 +1387,7 @@ namespace jank::analyze
     if(has_docstring)
     {
       auto const docstring_obj(l->data.rest().rest().first().unwrap());
-      if(docstring_obj->type != runtime::object_type::persistent_string)
+      if(docstring_obj.get_type() != runtime::object_type::persistent_string)
       {
         return error::analyze_invalid_def("The doc string for a 'def' must be a string.",
                                           object_source(docstring_obj),
@@ -1451,13 +1452,13 @@ namespace jank::analyze
                                          latest_expansion(macro_expansions));
     }
     auto const shift_obj{ it.first().unwrap() };
-    if(shift_obj.data->type != object_type::integer)
+    if(!runtime::is_integer(shift_obj))
     {
-      return error::analyze_invalid_case("Shift value should be an integer.",
+      return error::analyze_invalid_case("Shift value must be an integer.",
                                          meta_source(o->meta),
                                          latest_expansion(macro_expansions));
     }
-    auto const shift{ runtime::expect_object<runtime::obj::integer>(shift_obj) };
+    auto const shift{ runtime::to_i64(shift_obj) };
 
     it = it.rest();
     if(it.first().is_none())
@@ -1467,13 +1468,13 @@ namespace jank::analyze
                                          latest_expansion(macro_expansions));
     }
     auto const mask_obj{ it.first().unwrap() };
-    if(mask_obj.data->type != object_type::integer)
+    if(!runtime::is_integer(mask_obj))
     {
-      return error::analyze_invalid_case("Mask value should be an integer.",
+      return error::analyze_invalid_case("Mask value must be an integer.",
                                          meta_source(o->meta),
                                          latest_expansion(macro_expansions));
     }
-    auto const mask{ runtime::expect_object<runtime::obj::integer>(mask_obj) };
+    auto const mask{ runtime::to_i64(mask_obj) };
 
     it = it.rest();
     if(it.first().is_none())
@@ -1510,17 +1511,17 @@ namespace jank::analyze
           auto const e{ seq->first() };
           auto const k_obj{ e->data[0] };
           auto const v_obj{ e->data[1] };
-          if(k_obj.data->type != object_type::integer)
+          if(!runtime::is_integer(k_obj))
           {
             return err("Map key for case* is expected to be an integer.");
           }
-          auto const key{ runtime::expect_object<obj::integer>(k_obj) };
+          auto const key{ runtime::to_i64(k_obj) };
           auto const expr{ analyze(v_obj, current_frame, position, fn_ctx, needs_box) };
           if(expr.is_err())
           {
             return err(expr.expect_err()->message);
           }
-          ret.keys.push_back(key->data);
+          ret.keys.push_back(key);
           ret.exprs.push_back(expr.expect_ok());
         }
         return ret;
@@ -1543,8 +1544,8 @@ namespace jank::analyze
                                       current_frame,
                                       needs_box,
                                       value_expr.expect_ok(),
-                                      shift->data,
-                                      mask->data,
+                                      shift,
+                                      mask,
                                       default_expr.expect_ok(),
                                       std::move(pairs.keys),
                                       std::move(pairs.exprs));
@@ -1680,7 +1681,7 @@ namespace jank::analyze
                                                   latest_expansion(macro_expansions));
     }
     auto const &params_obj(first_form.unwrap());
-    if(params_obj->type != runtime::object_type::persistent_vector)
+    if(params_obj.get_type() != runtime::object_type::persistent_vector)
     {
       return error::analyze_invalid_fn_parameters("A function parameter vector must be a vector.",
                                                   object_source(params_obj),
@@ -1704,7 +1705,7 @@ namespace jank::analyze
     for(auto it(params->data.begin()); it != params->data.end(); ++it)
     {
       auto const &p(*it);
-      if(p->type != runtime::object_type::symbol)
+      if(p.get_type() != runtime::object_type::symbol)
       {
         auto const param_idx{ std::distance(params->data.begin(), it) };
         return error::analyze_invalid_fn_parameters("Each function parameter must be a symbol.",
@@ -1860,7 +1861,7 @@ namespace jank::analyze
 
     jtl::immutable_string name, unique_name;
     auto first_elem(list->data.rest().first().unwrap());
-    if(first_elem->type == runtime::object_type::symbol)
+    if(first_elem.get_type() == runtime::object_type::symbol)
     {
       auto const s(runtime::expect_object<runtime::obj::symbol>(first_elem));
       name = s->name;
@@ -1882,7 +1883,7 @@ namespace jank::analyze
 
     native_vector<expr::function_arity> arities;
 
-    if(first_elem->type == runtime::object_type::persistent_vector)
+    if(first_elem.get_type() == runtime::object_type::persistent_vector)
     {
       auto const result(analyze_fn_arity(make_box<runtime::obj::persistent_list>(list->data.rest()),
                                          name,
@@ -2211,7 +2212,7 @@ namespace jank::analyze
     }
 
     auto const bindings_obj(o->data.rest().first().unwrap());
-    if(bindings_obj->type != runtime::object_type::persistent_vector)
+    if(bindings_obj.get_type() != runtime::object_type::persistent_vector)
     {
       return error::analyze_invalid_let("The bindings of a 'let' must be in a vector.",
                                         object_source(bindings_obj),
@@ -2248,7 +2249,7 @@ namespace jank::analyze
       auto const &sym_obj(bindings->data[i]);
       auto const &val(bindings->data[i + 1]);
 
-      if(sym_obj->type != runtime::object_type::symbol)
+      if(sym_obj.get_type() != runtime::object_type::symbol)
       {
         return error::analyze_invalid_let("The left hand side of a 'let' binding must be a symbol.",
                                           object_source(sym_obj),
@@ -2351,7 +2352,7 @@ namespace jank::analyze
     }
 
     auto const bindings_obj(o->data.rest().first().unwrap());
-    if(bindings_obj->type != runtime::object_type::persistent_vector)
+    if(bindings_obj.get_type() != runtime::object_type::persistent_vector)
     {
       return error::analyze_invalid_letfn("The bindings of a 'letfn*' must be in a vector.",
                                           meta_source(bindings_obj),
@@ -2387,7 +2388,7 @@ namespace jank::analyze
     {
       auto const &sym_obj(bindings->data[i]);
 
-      if(sym_obj->type != runtime::object_type::symbol)
+      if(sym_obj.get_type() != runtime::object_type::symbol)
       {
         return error::analyze_invalid_letfn(
           "The left hand side of a 'letfn*' binding must be a symbol.",
@@ -2667,7 +2668,7 @@ namespace jank::analyze
     }
 
     auto const arg(o->data.rest().first().unwrap());
-    if(arg->type != runtime::object_type::symbol)
+    if(arg.get_type() != runtime::object_type::symbol)
     {
       return error::analyze_invalid_var_reference("The argument to 'var' must be a symbol.",
                                                   object_source(arg),
@@ -2860,7 +2861,7 @@ namespace jank::analyze
                 ->add_usage(read::parse::reparse_nth(item, 1));
             }
 
-            if(catch_sym_form->type != runtime::object_type::symbol)
+            if(catch_sym_form.get_type() != runtime::object_type::symbol)
             {
               return error::analyze_invalid_try(
                        "A symbol is required after 'catch', which is used as the binding to "
@@ -3206,7 +3207,7 @@ namespace jank::analyze
     bool needs_arg_box{ true };
 
     /* TODO: If this is a recursive call, note that and skip the var lookup. */
-    if(first->type == runtime::object_type::symbol)
+    if(first.get_type() == runtime::object_type::symbol)
     {
       auto const sym(runtime::expect_object<runtime::obj::symbol>(first));
       auto const found_special(specials().find(sym));
@@ -3840,7 +3841,7 @@ namespace jank::analyze
         ->add_usage(read::parse::reparse_nth(l, 1));
     }
     auto const obj{ llvm::cast<expr::primitive_literal>(string_expr.data)->data };
-    if(obj->type != runtime::object_type::persistent_string)
+    if(obj.get_type() != runtime::object_type::persistent_string)
     {
       return error::analyze_invalid_cpp_raw(
                "The first and only argument to 'cpp/raw' must be a string of C++ code.",
@@ -3917,13 +3918,17 @@ namespace jank::analyze
     jtl::string_result<cpp_util::literal_value_result> literal_res{ err("unset") };
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wswitch-enum"
-    switch(arg->type)
+    switch(arg.get_type())
 #pragma clang diagnostic pop
     {
       case object_type::integer:
         literal_res = cpp_util::resolve_literal_value(
           util::format("static_cast<jtl::i64>({})",
                        expect_object<runtime::obj::integer>(arg)->data));
+        break;
+      case object_type::small_integer:
+        literal_res = cpp_util::resolve_literal_value(
+          util::format("static_cast<jtl::i64>({})", runtime::detail::as_int(arg.data)));
         break;
       case object_type::real:
         literal_res = cpp_util::resolve_literal_value(
@@ -4616,7 +4621,7 @@ namespace jank::analyze
         {
           return error::internal_analyze_failure(
             util::format("Unimplemented analysis for object type '{}'.",
-                         object_type_str(typed_o->type)),
+                         object_type_str(typed_o.get_type())),
             object_source(o),
             latest_expansion(macro_expansions));
         }
@@ -4640,7 +4645,7 @@ namespace jank::analyze
                                   expression_position const position,
                                   jtl::option<expr::function_context_ref> const &fn_ctx)
   {
-    if(o->type == object_type::symbol)
+    if(o.get_type() == object_type::symbol)
     {
       auto const res{ analyze_cpp_symbol(expect_object<obj::symbol>(o),
                                          current_frame,
@@ -4717,7 +4722,7 @@ namespace jank::analyze
         auto const seq{ typed_o->seq() };
         auto const first{ runtime::first(seq) };
 
-        if(first->type == object_type::keyword)
+        if(first.get_type() == object_type::keyword)
         {
           static auto const ptr{ runtime::__rt_ctx->intern_keyword("*").expect_ok() };
           static auto const lref{ runtime::__rt_ctx->intern_keyword("&").expect_ok() };
@@ -4992,21 +4997,22 @@ namespace jank::analyze
                 }
 
                 auto const size_obj{ runtime::second(next(seq)) };
-                if(auto const size{ runtime::dyn_cast<obj::integer>(size_obj) }; size.is_some())
+                if(runtime::is_integer(size_obj))
                 {
-                  if(size->data < 0)
+                  auto const size{ runtime::to_i64(size_obj) };
+                  if(size < 0)
                   {
                     return error::analyze_invalid_cpp_dsl(
                       "Array sizes must be either zero or positive integers.",
                       object_source(o),
                       latest_expansion(macro_expansions));
                   }
-                  return Cpp::GetArrayType(type, size->data);
+                  return Cpp::GetArrayType(type, size);
                 }
 
                 return error::analyze_invalid_cpp_dsl(
                   util::format("Invalid array size. An integer was expected, but a {} was found.",
-                               object_type_str(size_obj->type)),
+                               object_type_str(size_obj.get_type())),
                   object_source(o),
                   latest_expansion(macro_expansions));
               });
@@ -5050,7 +5056,7 @@ namespace jank::analyze
                     return error::analyze_invalid_cpp_dsl(
                       util::format(
                         "A sequence of parameter types was expected, but a {} was found instead.",
-                        object_type_str(params->type)),
+                        object_type_str(params.get_type())),
                       object_source(params),
                       latest_expansion(macro_expansions));
                   },
@@ -5066,7 +5072,7 @@ namespace jank::analyze
             }
 
             auto const member_arg{ runtime::second(runtime::next(seq)) };
-            if(member_arg->type != object_type::symbol)
+            if(member_arg.get_type() != object_type::symbol)
             {
               return error::analyze_invalid_cpp_dsl("Member names need to be symbols.",
                                                     object_source(member_arg),
@@ -5086,7 +5092,7 @@ namespace jank::analyze
             {
               return error::analyze_invalid_cpp_dsl(
                 util::format("There is no '{}' member within '{}'.",
-                             member_arg->to_string(),
+                             member_arg.to_string(),
                              cpp_util::get_qualified_type_name(type)),
                 object_source(member_arg),
                 latest_expansion(macro_expansions));
@@ -5099,7 +5105,7 @@ namespace jank::analyze
             {
               return error::analyze_invalid_cpp_dsl(
                 util::format("There is no '{}' member within '{}'.",
-                             member_arg->to_string(),
+                             member_arg.to_string(),
                              cpp_util::get_qualified_type_name(type)),
                 object_source(member_arg),
                 latest_expansion(macro_expansions));
@@ -5197,7 +5203,7 @@ namespace jank::analyze
             }
 
             auto const member_arg{ runtime::second(runtime::next(seq)) };
-            if(member_arg->type != object_type::symbol)
+            if(member_arg.get_type() != object_type::symbol)
             {
               return error::analyze_invalid_cpp_dsl("Member names need to be symbols.",
                                                     object_source(member_arg),
@@ -5217,7 +5223,7 @@ namespace jank::analyze
             {
               return error::analyze_invalid_cpp_dsl(
                 util::format("There is no '{}' member within '{}'.",
-                             member_arg->to_string(),
+                             member_arg.to_string(),
                              cpp_util::get_qualified_type_name(type)),
                 object_source(member_arg),
                 latest_expansion(macro_expansions));
@@ -5230,7 +5236,7 @@ namespace jank::analyze
             {
               return error::analyze_invalid_cpp_dsl(
                 util::format("There is no '{}' member within '{}'.",
-                             member_arg->to_string(),
+                             member_arg.to_string(),
                              cpp_util::get_qualified_type_name(type)),
                 object_source(member_arg),
                 latest_expansion(macro_expansions));
@@ -5241,7 +5247,7 @@ namespace jank::analyze
                 util::format(
                   "A member variable or function was expected here, but '{}::{}' was found.",
                   cpp_util::get_qualified_type_name(type),
-                  member_arg->to_string()),
+                  member_arg.to_string()),
                 object_source(member_arg),
                 latest_expansion(macro_expansions));
             }
@@ -5250,7 +5256,7 @@ namespace jank::analyze
               return error::analyze_invalid_cpp_dsl(
                 util::format("A non-static member was expected here, but '{}::{}' is static.",
                              cpp_util::get_qualified_type_name(type),
-                             member_arg->to_string()),
+                             member_arg.to_string()),
                 object_source(member_arg),
                 latest_expansion(macro_expansions));
             }
@@ -5280,7 +5286,7 @@ namespace jank::analyze
             object_source(o),
             latest_expansion(macro_expansions));
         }
-        else if(first->type == object_type::symbol)
+        else if(first.get_type() == object_type::symbol)
         {
           static obj::symbol const cpp_type{ "cpp", "dsl" };
           if(expect_object<obj::symbol>(first)->equal(cpp_type))
@@ -5320,11 +5326,12 @@ namespace jank::analyze
           native_vector<Cpp::TemplateArgInfo> args;
           for(auto const arg : make_sequence_range(rest(typed_o)))
           {
-            if(auto const int_arg{ dyn_cast<obj::integer>(arg) }; int_arg.is_some())
+            if(runtime::is_integer(arg))
             {
+              auto const int_arg{ runtime::to_i64(arg) };
               static auto const int_type{ cpp_util::resolve_literal_type("long long").expect_ok() };
               jtl::string_builder sb;
-              sb(int_arg->data);
+              sb(int_arg);
               /* XXX: Safe, due to the GC. */
               args.emplace_back(int_type.data, sb.release().c_str());
               continue;
@@ -5442,7 +5449,7 @@ namespace jank::analyze
 
   bool processor::is_special(runtime::object_ref const form)
   {
-    if(form->type != runtime::object_type::symbol)
+    if(form.get_type() != runtime::object_type::symbol)
     {
       return false;
     }

--- a/compiler+runtime/src/cpp/jank/c_api.cpp
+++ b/compiler+runtime/src/cpp/jank/c_api.cpp
@@ -942,9 +942,9 @@ extern "C"
 
   static i64 to_integer_or_hash(object const *o)
   {
-    if(o->type == object_type::integer)
+    if(is_integer(o))
     {
-      return expect_object<obj::integer>(o)->data;
+      return to_i64(o);
     }
 
     return to_hash(o);

--- a/compiler+runtime/src/cpp/jank/codegen/api.cpp
+++ b/compiler+runtime/src/cpp/jank/codegen/api.cpp
@@ -29,6 +29,11 @@ jank::runtime::obj::integer_ref _jank_int(jtl::i64 const i)
   return jank::runtime::make_box<jank::runtime::obj::integer>(i);
 }
 
+jank::runtime::obj::small_integer_ref _jank_small_int(jtl::i64 const i)
+{
+  return i;
+}
+
 jank::runtime::obj::real_ref _jank_real(jtl::f64 const r)
 {
   return jank::runtime::make_box<jank::runtime::obj::real>(r);

--- a/compiler+runtime/src/cpp/jank/codegen/cpp_processor.cpp
+++ b/compiler+runtime/src/cpp/jank/codegen/cpp_processor.cpp
@@ -130,6 +130,7 @@ namespace jank::codegen
     /* NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables) */
     global_vars;
 
+  /* TODO: integer_ref codegen needs to handle small integers. */
   static identifier lift_constant(identifier const &name, builder &b)
   {
     auto const o{ b.module->lifted_constants.at(name) };
@@ -1113,7 +1114,8 @@ namespace jank::codegen
     }
 
     util::format_to(b.body_buffer,
-                    "switch(jank_shift_mask_case_integer({}.get(), {}, {})) {",
+                    "switch(jank_shift_mask_case_integer(static_cast<jank::runtime::object*>({}."
+                    "data), {}, {})) {",
                     inst->value,
                     inst->shift,
                     inst->mask);
@@ -1303,6 +1305,11 @@ namespace jank::codegen
           util::format_to(b.body_buffer, ", ");
         }
 
+        if(param_type && Cpp::IsPointerType(param_type) && is_any_object(arg_type))
+        {
+          util::format_to(b.body_buffer, "static_cast<jank::runtime::object*>(");
+        }
+
         if(param_type && Cpp::IsRvalueReferenceType(param_type))
         {
           util::format_to(b.body_buffer, "std::move({})", arg_tmp);
@@ -1314,7 +1321,7 @@ namespace jank::codegen
 
         if(param_type && Cpp::IsPointerType(param_type) && is_any_object(arg_type))
         {
-          util::format_to(b.body_buffer, ".get()");
+          util::format_to(b.body_buffer, ".data)");
         }
         need_comma = true;
       }

--- a/compiler+runtime/src/cpp/jank/codegen/cpp_processor.cpp
+++ b/compiler+runtime/src/cpp/jank/codegen/cpp_processor.cpp
@@ -220,6 +220,10 @@ namespace jank::codegen
           {
             util::format_to(buffer, "_jank_int({})", typed_o->data);
           }
+          else if constexpr(std::same_as<T, obj::small_integer>)
+          {
+            util::format_to(buffer, "_jank_small_int({})", typed_o->data);
+          }
           else if constexpr(std::same_as<T, obj::real>)
           {
             util::format_to(buffer, "_jank_real(");

--- a/compiler+runtime/src/cpp/jank/error/analyze.cpp
+++ b/compiler+runtime/src/cpp/jank/error/analyze.cpp
@@ -188,7 +188,7 @@ namespace jank::error
                                               runtime::object_ref const expansion)
   {
     return make_error(kind::analyze_macro_expansion_exception,
-                      e->type == runtime::object_type::persistent_string
+                      e.get_type() == runtime::object_type::persistent_string
                         ? runtime::to_string(e)
                         : runtime::to_code_string(e),
                       source,

--- a/compiler+runtime/src/cpp/jank/evaluate.cpp
+++ b/compiler+runtime/src/cpp/jank/evaluate.cpp
@@ -320,7 +320,7 @@ namespace jank::evaluate
   object_ref eval(expr::call_ref const expr)
   {
     auto source(eval(expr->source_expr));
-    while(source->type == object_type::var)
+    while(source.get_type() == object_type::var)
     {
       source = deref(source);
     }
@@ -431,7 +431,7 @@ namespace jank::evaluate
 
   object_ref eval(expr::primitive_literal_ref const expr)
   {
-    if(expr->data->type == object_type::keyword)
+    if(expr->data.get_type() == object_type::keyword)
     {
       auto const d(expect_object<obj::keyword>(expr->data));
       return __rt_ctx->intern_keyword(d->sym->ns, d->sym->name).expect_ok();

--- a/compiler+runtime/src/cpp/jank/hash.cpp
+++ b/compiler+runtime/src/cpp/jank/hash.cpp
@@ -155,7 +155,7 @@ namespace jank::hash
 
   u32 visit(runtime::object_ref const o)
   {
-    return runtime::visit_object([](auto const typed_o) -> u32 { return typed_o->to_hash(); }, o);
+    return runtime::visit_object([](auto const typed_o) -> u32 { return typed_o.to_hash(); }, o);
   }
 
   template <typename T>
@@ -185,7 +185,7 @@ namespace jank::hash
         }
         else
         {
-          return typed_sequence->to_hash();
+          return typed_sequence.to_hash();
         }
       },
       sequence);
@@ -211,7 +211,7 @@ namespace jank::hash
         }
         else
         {
-          return typed_sequence->to_hash();
+          return typed_sequence.to_hash();
         }
       },
       sequence);

--- a/compiler+runtime/src/cpp/jank/ir/print.cpp
+++ b/compiler+runtime/src/cpp/jank/ir/print.cpp
@@ -54,7 +54,7 @@ namespace jank::ir
     util::format_to(sb,
                     "{:name {} :op :literal :value {} :type \"{}\"}",
                     name,
-                    obj->to_code_string(),
+                    obj.to_code_string(),
                     get_qualified_type_name(type));
   }
 
@@ -681,7 +681,7 @@ namespace jank::ir
           print_indent(sb, indent);
         }
         needs_indent = true;
-        util::format_to(sb, "{} {}", c.first, c.second->to_code_string());
+        util::format_to(sb, "{} {}", c.first, c.second.to_code_string());
       }
     }
     util::format_to(sb, "}\n");

--- a/compiler+runtime/src/cpp/jank/read/parse.cpp
+++ b/compiler+runtime/src/cpp/jank/read/parse.cpp
@@ -759,7 +759,7 @@ namespace jank::read::parse
       return list_result;
     }
     else if(list_result.expect_ok().is_none()
-            || list_result.expect_ok().unwrap().ptr->type != object_type::persistent_list)
+            || list_result.expect_ok().unwrap().ptr.get_type() != object_type::persistent_list)
     {
       return error::internal_parse_failure("Value after #( must be present.",
                                            { start_token.start, latest_token.end });
@@ -806,7 +806,7 @@ namespace jank::read::parse
       return error::parse_invalid_reader_var({ start_token.start, latest_token.end },
                                              "Value after #' must be present.");
     }
-    else if(sym_result.expect_ok().unwrap().ptr->type != object_type::symbol)
+    else if(sym_result.expect_ok().unwrap().ptr.get_type() != object_type::symbol)
     {
       return error::parse_invalid_reader_var({ start_token.start, latest_token.end },
                                              "Value after #' must be a symbol.");
@@ -837,7 +837,7 @@ namespace jank::read::parse
       return error::parse_invalid_reader_symbolic_value("Value after ## must be present.",
                                                         { start_token.start, latest_token.end });
     }
-    else if(sym_result.expect_ok().unwrap().ptr->type != object_type::symbol)
+    else if(sym_result.expect_ok().unwrap().ptr.get_type() != object_type::symbol)
     {
       return error::parse_invalid_reader_symbolic_value("Value after ## must be a symbol.",
                                                         { start_token.start, latest_token.end });
@@ -1019,7 +1019,7 @@ namespace jank::read::parse
           return error::parse_invalid_data_reader(
             util::format("The 'clojure.core/*data-readers*' var needs to be a map between the tag "
                          "symbol and it's corresponding data reader function. Found a {} instead.",
-                         object_type_str(data_readers->type)),
+                         object_type_str(data_readers.get_type())),
             { start_token.start, sym_end.end });
         },
         data_readers,
@@ -1036,7 +1036,7 @@ namespace jank::read::parse
       {
         if(is_callable(data_reader))
         {
-          return object_source_info{ data_reader->call(form), form_token, form_end };
+          return object_source_info{ data_reader.call(form), form_token, form_end };
         }
         else
         {
@@ -1044,7 +1044,7 @@ namespace jank::read::parse
             util::format("The data reader for the tagged literal '#{}' needs to be a function. "
                          "Found a {} instead.",
                          sym->to_string(),
-                         object_type_str(data_reader->type)),
+                         object_type_str(data_reader.get_type())),
             { start_token.start, sym_end.end });
         }
       }
@@ -1060,9 +1060,7 @@ namespace jank::read::parse
       {
         if(is_callable(default_data_reader_fn))
         {
-          return object_source_info{ default_data_reader_fn->call(sym, form),
-                                     form_token,
-                                     form_end };
+          return object_source_info{ default_data_reader_fn.call(sym, form), form_token, form_end };
         }
         else
         {
@@ -1070,7 +1068,7 @@ namespace jank::read::parse
             util::format(
               "The 'clojure.core/*default-data-reader-fn*' var must be a function taking 2 "
               "arguments, the tag and the form immediately after the tag. Found a {} instead.",
-              object_type_str(default_data_reader_fn->type)),
+              object_type_str(default_data_reader_fn.get_type())),
             { start_token.start, latest_token.end });
         }
       }
@@ -1165,7 +1163,7 @@ namespace jank::read::parse
 
       auto const feature{ it->expect_ok().unwrap() };
 
-      if(feature.ptr->type != object_type::keyword)
+      if(feature.ptr.get_type() != object_type::keyword)
       {
         return error::parse_invalid_reader_conditional({ feature.start.start, feature.end.end },
                                                        "Feature must be a keyword.");
@@ -1418,7 +1416,7 @@ namespace jank::read::parse
         object_ref const item{ s.is_some() ? first(s).erase() : s.erase() };
 
         return make_box<obj::symbol>("clojure.core", (splice ? "unquote-splicing" : "unquote"))
-          ->equal(*item);
+          .equal(item);
       },
       [] { return false; },
       form);
@@ -1436,19 +1434,19 @@ namespace jank::read::parse
     /* By default, all symbols get qualified. However, any symbol ending in # does not get
      * qualified, but instead gets a gensym (a unique name). The unique names are kept in
      * a bound map for reproducibility. */
-    else if(form->type == object_type::symbol)
+    else if(form.get_type() == object_type::symbol)
     {
       auto sym(expect_object<obj::symbol>(form));
       if(sym->ns.empty() && sym->name.ends_with('#'))
       {
         auto const env(__rt_ctx->gensym_env_var->deref());
-        if(env->type == object_type::nil)
+        if(env.get_type() == object_type::nil)
         {
           return err(error::internal_parse_failure("Missing gensym env."));
         }
 
         auto gensym(get(env, sym));
-        if(gensym->type == object_type::nil)
+        if(gensym.get_type() == object_type::nil)
         {
           gensym = __rt_ctx->unique_symbol(sym->name);
           __rt_ctx->gensym_env_var->set(assoc(env, sym, gensym)).expect_ok();
@@ -1484,9 +1482,11 @@ namespace jank::read::parse
     }
     /* Clojure treats these specially, perhaps as a small optimization, by not quoting. We can
      * do the same for now, but quoting all of these has no effect. */
-    else if(form->type == object_type::keyword || form->type == object_type::persistent_string
-            || form->type == object_type::integer || form->type == object_type::real
-            || form->type == object_type::character || form->type == object_type::nil)
+    else if(form.get_type() == object_type::keyword
+            || form.get_type() == object_type::persistent_string
+            || form.get_type() == object_type::integer
+            || form.get_type() == object_type::small_integer || form.get_type() == object_type::real
+            || form.get_type() == object_type::character || form.get_type() == object_type::nil)
     {
       ret = form;
     }
@@ -1884,17 +1884,11 @@ namespace jank::read::parse
                                         "A ratio may not have a denominator of zero.");
     }
     if(auto const ratio{ obj::ratio::create(ratio_data.numerator, ratio_data.denominator) };
-       ratio->type == object_type::ratio)
+       ratio.get_type() == object_type::ratio || ratio.get_type() == object_type::integer
+       || ratio.get_type() == object_type::small_integer
+       || ratio.get_type() == object_type::big_integer)
     {
-      return object_source_info{ expect_object<obj::ratio>(ratio), token, token };
-    }
-    else if(ratio->type == object_type::integer)
-    {
-      return object_source_info{ expect_object<obj::integer>(ratio), token, token };
-    }
-    else if(ratio->type == object_type::big_integer)
-    {
-      return object_source_info{ expect_object<obj::big_integer>(ratio), token, token };
+      return object_source_info{ ratio, token, token };
     }
     else
     {

--- a/compiler+runtime/src/cpp/jank/read/reparse.cpp
+++ b/compiler+runtime/src/cpp/jank/read/reparse.cpp
@@ -5,7 +5,7 @@
 #include <jank/runtime/core/meta.hpp>
 #include <jank/runtime/visit.hpp>
 #include <jank/runtime/module/loader.hpp>
-#include <jank/util/fmt.hpp>
+#include <jank/util/fmt/print.hpp>
 #include <jank/error/parse.hpp>
 
 namespace jank::read::parse

--- a/compiler+runtime/src/cpp/jank/runtime/context.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/context.cpp
@@ -346,7 +346,7 @@ namespace jank::runtime
     {
       throw std::runtime_error{ util::format(
         "The reader options need to be a map. Found a {} instead.",
-        runtime::object_type_str(reader_opts->type)) };
+        runtime::object_type_str(reader_opts.get_type())) };
     }
 
     static auto const read_cond_kw{ __rt_ctx->intern_keyword("", "read-cond").expect_ok() };
@@ -385,7 +385,7 @@ namespace jank::runtime
       {
         throw std::runtime_error{ util::format(
           "The :features reader option needs to be a set. Found a {} instead.",
-          runtime::object_type_str(features->type)) };
+          runtime::object_type_str(features.get_type())) };
       }
 
       extended_features = features;
@@ -1026,7 +1026,7 @@ namespace jank::runtime
 
   jtl::string_result<void> context::push_thread_bindings(object_ref const bindings)
   {
-    if(bindings->type != object_type::persistent_hash_map)
+    if(bindings.get_type() != object_type::persistent_hash_map)
     {
       return err(util::format("invalid thread binding map (must be hash map): {}",
                               runtime::to_code_string(bindings)));
@@ -1062,7 +1062,7 @@ namespace jank::runtime
 
       /* The binding may already be a thread binding if we're just pushing the previous
        * bindings again to give a scratch pad for some upcoming code. */
-      if(entry->data[1]->type == object_type::var_thread_binding)
+      if(entry->data[1].get_type() == object_type::var_thread_binding)
       {
         frame.bindings = frame.bindings->assoc(
           var,

--- a/compiler+runtime/src/cpp/jank/runtime/core.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core.cpp
@@ -18,7 +18,7 @@ namespace jank::runtime
 {
   jtl::immutable_string type(object_ref const o)
   {
-    return object_type_str(o->type);
+    return object_type_str(o.get_type());
   }
 
   bool is_nil(object_ref const o)
@@ -43,27 +43,27 @@ namespace jank::runtime
 
   bool is_string(object_ref const o)
   {
-    return o->type == object_type::persistent_string;
+    return o.get_type() == object_type::persistent_string;
   }
 
   bool is_char(object_ref const o)
   {
-    return o->type == object_type::character;
+    return o.get_type() == object_type::character;
   }
 
   bool is_symbol(object_ref const o)
   {
-    return o->type == object_type::symbol;
+    return o.get_type() == object_type::symbol;
   }
 
   bool is_simple_symbol(object_ref const o)
   {
-    return o->type == object_type::symbol && expect_object<obj::symbol>(o)->ns.empty();
+    return o.get_type() == object_type::symbol && expect_object<obj::symbol>(o)->ns.empty();
   }
 
   bool is_qualified_symbol(object_ref const o)
   {
-    return o->type == object_type::symbol && !expect_object<obj::symbol>(o)->ns.empty();
+    return o.get_type() == object_type::symbol && !expect_object<obj::symbol>(o)->ns.empty();
   }
 
   object_ref to_unqualified_symbol(object_ref const o)
@@ -91,7 +91,7 @@ namespace jank::runtime
         else
         {
           throw std::runtime_error{ util::format("can't convert {} to a symbol",
-                                                 typed_o->to_code_string()) };
+                                                 typed_o.to_code_string()) };
         }
       },
       o);
@@ -122,7 +122,7 @@ namespace jank::runtime
         else
         {
           throw std::runtime_error{ util::format("expected a sequence: {}",
-                                                 typed_args->to_string()) };
+                                                 typed_args.to_string()) };
         }
       },
       args);
@@ -154,7 +154,7 @@ namespace jank::runtime
         else
         {
           throw std::runtime_error{ util::format("expected a sequence: {}",
-                                                 typed_more->to_string()) };
+                                                 typed_more.to_string()) };
         }
       },
       args);
@@ -181,7 +181,7 @@ namespace jank::runtime
         else
         {
           throw std::runtime_error{ util::format("expected a sequence: {}",
-                                                 typed_args->to_string()) };
+                                                 typed_args.to_string()) };
         }
       },
       args);
@@ -213,7 +213,7 @@ namespace jank::runtime
         else
         {
           throw std::runtime_error{ util::format("expected a sequence: {}",
-                                                 typed_args->to_string()) };
+                                                 typed_args.to_string()) };
         }
       },
       args);
@@ -284,7 +284,7 @@ namespace jank::runtime
         }
         else
         {
-          throw std::runtime_error{ util::format("not nameable: {}", typed_o->to_string()) };
+          throw std::runtime_error{ util::format("not nameable: {}", typed_o.to_string()) };
         }
       },
       o);
@@ -307,7 +307,7 @@ namespace jank::runtime
         }
         else
         {
-          throw std::runtime_error{ util::format("not nameable: {}", typed_o->to_string()) };
+          throw std::runtime_error{ util::format("not nameable: {}", typed_o.to_string()) };
         }
       },
       o);
@@ -327,13 +327,13 @@ namespace jank::runtime
 
   object_ref keyword(object_ref const ns, object_ref const name)
   {
-    if(!ns.is_nil() && ns->type != object_type::persistent_string)
+    if(!ns.is_nil() && ns.get_type() != object_type::persistent_string)
     {
       throw std::runtime_error{ util::format(
         "The 'keyword' function expects a namespace to be 'nil' or a 'string', got {} instead.",
         runtime::to_code_string(ns)) };
     }
-    if(name->type != object_type::persistent_string)
+    if(name.get_type() != object_type::persistent_string)
     {
       throw std::runtime_error{ util::format(
         "The 'keyword' function expects the name to be a 'string', got {} instead.",
@@ -350,27 +350,27 @@ namespace jank::runtime
 
   bool is_keyword(object_ref const o)
   {
-    return o->type == object_type::keyword;
+    return o.get_type() == object_type::keyword;
   }
 
   bool is_simple_keyword(object_ref const o)
   {
-    return o->type == object_type::keyword && expect_object<obj::keyword>(o)->sym->ns.empty();
+    return o.get_type() == object_type::keyword && expect_object<obj::keyword>(o)->sym->ns.empty();
   }
 
   bool is_qualified_keyword(object_ref const o)
   {
-    return o->type == object_type::keyword && !expect_object<obj::keyword>(o)->sym->ns.empty();
+    return o.get_type() == object_type::keyword && !expect_object<obj::keyword>(o)->sym->ns.empty();
   }
 
   bool is_callable(object_ref const o)
   {
-    return (o->behaviors & object_behavior::call) != object_behavior::none;
+    return o.has_behavior(object_behavior::call);
   }
 
   uhash to_hash(object_ref const o)
   {
-    return visit_object([=](auto const typed_o) -> uhash { return typed_o->to_hash(); }, o);
+    return visit_object([=](auto const typed_o) -> uhash { return typed_o.to_hash(); }, o);
   }
 
   object_ref macroexpand1(object_ref const o)
@@ -472,7 +472,7 @@ namespace jank::runtime
         else
         {
           throw std::runtime_error{ util::format("not derefable: {}",
-                                                 object_type_str(typed_o->type)) };
+                                                 object_type_str(typed_o.get_type())) };
         }
       },
       o);
@@ -491,7 +491,7 @@ namespace jank::runtime
         else
         {
           throw std::runtime_error{ util::format("not realizable: {}",
-                                                 object_type_str(typed_o->type)) };
+                                                 object_type_str(typed_o.get_type())) };
         }
       },
       o);
@@ -504,7 +504,7 @@ namespace jank::runtime
 
   bool is_volatile(object_ref const o)
   {
-    return o->type == object_type::volatile_;
+    return o.get_type() == object_type::volatile_;
   }
 
   object_ref vswap(object_ref const v, object_ref const fn)
@@ -541,7 +541,7 @@ namespace jank::runtime
 
   object_ref force(object_ref const o)
   {
-    if(o->type == object_type::delay)
+    if(o.get_type() == object_type::delay)
     {
       return expect_object<obj::delay>(o)->deref();
     }
@@ -555,7 +555,7 @@ namespace jank::runtime
 
   bool is_tagged_literal(object_ref const o)
   {
-    return o->type == object_type::tagged_literal;
+    return o.get_type() == object_type::tagged_literal;
   }
 
   object_ref re_pattern(object_ref const o)
@@ -646,7 +646,7 @@ namespace jank::runtime
 
   object_ref parse_uuid(object_ref const o)
   {
-    if(o->type == object_type::persistent_string)
+    if(o.get_type() == object_type::persistent_string)
     {
       try
       {
@@ -659,13 +659,14 @@ namespace jank::runtime
     }
     else
     {
-      throw std::runtime_error{ util::format("expected string, got {}", object_type_str(o->type)) };
+      throw std::runtime_error{ util::format("expected string, got {}",
+                                             object_type_str(o.get_type())) };
     }
   }
 
   bool is_uuid(object_ref const o)
   {
-    return o->type == object_type::uuid;
+    return o.get_type() == object_type::uuid;
   }
 
   object_ref random_uuid()
@@ -675,15 +676,15 @@ namespace jank::runtime
 
   bool is_inst(object_ref const o)
   {
-    return o->type == object_type::inst;
+    return o.get_type() == object_type::inst;
   }
 
   i64 inst_ms(object_ref const o)
   {
-    if(o->type != object_type::inst)
+    if(o.get_type() != object_type::inst)
     {
       throw std::runtime_error{ util::format("The function 'inst-ms' expects an inst, got {}",
-                                             object_type_str(o->type)) };
+                                             object_type_str(o.get_type())) };
     }
 
     return std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -705,7 +706,7 @@ namespace jank::runtime
         {
           throw std::runtime_error{ util::format(
             "Value does not support 'add-watch' because it is not ref_like: {}",
-            typed_reference->to_code_string()) };
+            typed_reference.to_code_string()) };
         }
       },
       reference);
@@ -727,7 +728,7 @@ namespace jank::runtime
         {
           throw std::runtime_error{ util::format(
             "Value does not support 'remove-watch' because it is not ref_like: {}",
-            typed_reference->to_code_string()) };
+            typed_reference.to_code_string()) };
         }
       },
       reference);
@@ -880,11 +881,11 @@ namespace jank::runtime
 
   object_ref read_string(object_ref const form_string, object_ref const opts)
   {
-    if(form_string->type != object_type::persistent_string)
+    if(form_string.get_type() != object_type::persistent_string)
     {
       throw std::runtime_error{ util::format(
         "Argument to `read-string` needs to be a string representing a form. Found a {} instead.",
-        object_type_str(form_string->type)) };
+        object_type_str(form_string.get_type())) };
     }
 
     auto const typed_o{ expect_object<obj::persistent_string>(form_string) };
@@ -893,11 +894,11 @@ namespace jank::runtime
 
   object_ref read_file(object_ref const file_path, object_ref const opts)
   {
-    if(file_path->type != object_type::persistent_string)
+    if(file_path.get_type() != object_type::persistent_string)
     {
       throw std::runtime_error{ util::format("Argument to `read-file` needs to be a string "
                                              "representing a file path. Found a {} instead.",
-                                             object_type_str(file_path->type)) };
+                                             object_type_str(file_path.get_type())) };
     }
 
     auto const typed_o{ expect_object<obj::persistent_string>(file_path) };

--- a/compiler+runtime/src/cpp/jank/runtime/core/call.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/call.cpp
@@ -285,22 +285,22 @@ namespace jank::runtime
           make_box<obj::native_array_sequence>(a1, a2, a3, a4, a5, a6, a7, a8, a9));
       case mask_variadic_arity(1):
         return source.call(a1,
-                            make_box<obj::native_array_sequence>(a2, a3, a4, a5, a6, a7, a8, a9));
+                           make_box<obj::native_array_sequence>(a2, a3, a4, a5, a6, a7, a8, a9));
       case mask_variadic_arity(2):
         return source.call(a1,
-                            a2,
-                            make_box<obj::native_array_sequence>(a3, a4, a5, a6, a7, a8, a9));
+                           a2,
+                           make_box<obj::native_array_sequence>(a3, a4, a5, a6, a7, a8, a9));
       case mask_variadic_arity(3):
         return source.call(a1,
-                            a2,
-                            a3,
-                            make_box<obj::native_array_sequence>(a4, a5, a6, a7, a8, a9));
+                           a2,
+                           a3,
+                           make_box<obj::native_array_sequence>(a4, a5, a6, a7, a8, a9));
       case mask_variadic_arity(4):
         return source.call(a1,
-                            a2,
-                            a3,
-                            a4,
-                            make_box<obj::native_array_sequence>(a5, a6, a7, a8, a9));
+                           a2,
+                           a3,
+                           a4,
+                           make_box<obj::native_array_sequence>(a5, a6, a7, a8, a9));
       case mask_variadic_arity(5):
         return source
           .call(a1, a2, a3, a4, a5, make_box<obj::native_array_sequence>(a6, a7, a8, a9));
@@ -349,19 +349,19 @@ namespace jank::runtime
           make_box<obj::native_array_sequence>(a2, a3, a4, a5, a6, a7, a8, a9, a10));
       case mask_variadic_arity(2):
         return source.call(a1,
-                            a2,
-                            make_box<obj::native_array_sequence>(a3, a4, a5, a6, a7, a8, a9, a10));
+                           a2,
+                           make_box<obj::native_array_sequence>(a3, a4, a5, a6, a7, a8, a9, a10));
       case mask_variadic_arity(3):
         return source.call(a1,
-                            a2,
-                            a3,
-                            make_box<obj::native_array_sequence>(a4, a5, a6, a7, a8, a9, a10));
+                           a2,
+                           a3,
+                           make_box<obj::native_array_sequence>(a4, a5, a6, a7, a8, a9, a10));
       case mask_variadic_arity(4):
         return source.call(a1,
-                            a2,
-                            a3,
-                            a4,
-                            make_box<obj::native_array_sequence>(a5, a6, a7, a8, a9, a10));
+                           a2,
+                           a3,
+                           a4,
+                           make_box<obj::native_array_sequence>(a5, a6, a7, a8, a9, a10));
       case mask_variadic_arity(5):
         return source
           .call(a1, a2, a3, a4, a5, make_box<obj::native_array_sequence>(a6, a7, a8, a9, a10));
@@ -445,10 +445,10 @@ namespace jank::runtime
           packed.insert(packed.end(), { a5, a6, a7, a8, a9, a10 });
           std::copy(rest->data.begin(), rest->data.end(), std::back_inserter(packed));
           return source.call(a1,
-                              a2,
-                              a3,
-                              a4,
-                              make_box<obj::native_vector_sequence>(std::move(packed)));
+                             a2,
+                             a3,
+                             a4,
+                             make_box<obj::native_vector_sequence>(std::move(packed)));
         }
       case mask_variadic_arity(5):
         {
@@ -465,13 +465,8 @@ namespace jank::runtime
           packed.reserve(4 + rest->count());
           packed.insert(packed.end(), { a7, a8, a9, a10 });
           std::copy(rest->data.begin(), rest->data.end(), std::back_inserter(packed));
-          return source.call(a1,
-                              a2,
-                              a3,
-                              a4,
-                              a5,
-                              a6,
-                              make_box<obj::native_vector_sequence>(std::move(packed)));
+          return source
+            .call(a1, a2, a3, a4, a5, a6, make_box<obj::native_vector_sequence>(std::move(packed)));
         }
       case mask_variadic_arity(7):
         {
@@ -480,13 +475,13 @@ namespace jank::runtime
           packed.insert(packed.end(), { a8, a9, a10 });
           std::copy(rest->data.begin(), rest->data.end(), std::back_inserter(packed));
           return source.call(a1,
-                              a2,
-                              a3,
-                              a4,
-                              a5,
-                              a6,
-                              a7,
-                              make_box<obj::native_vector_sequence>(std::move(packed)));
+                             a2,
+                             a3,
+                             a4,
+                             a5,
+                             a6,
+                             a7,
+                             make_box<obj::native_vector_sequence>(std::move(packed)));
         }
       case mask_variadic_arity(8):
         {
@@ -495,14 +490,14 @@ namespace jank::runtime
           packed.insert(packed.end(), { a9, a10 });
           std::copy(rest->data.begin(), rest->data.end(), std::back_inserter(packed));
           return source.call(a1,
-                              a2,
-                              a3,
-                              a4,
-                              a5,
-                              a6,
-                              a7,
-                              a8,
-                              make_box<obj::native_vector_sequence>(std::move(packed)));
+                             a2,
+                             a3,
+                             a4,
+                             a5,
+                             a6,
+                             a7,
+                             a8,
+                             make_box<obj::native_vector_sequence>(std::move(packed)));
         }
       case mask_variadic_arity(9):
         {
@@ -511,15 +506,15 @@ namespace jank::runtime
           packed.insert(packed.end(), { a10 });
           std::copy(rest->data.begin(), rest->data.end(), std::back_inserter(packed));
           return source.call(a1,
-                              a2,
-                              a3,
-                              a4,
-                              a5,
-                              a6,
-                              a7,
-                              a8,
-                              a9,
-                              make_box<obj::native_vector_sequence>(std::move(packed)));
+                             a2,
+                             a3,
+                             a4,
+                             a5,
+                             a6,
+                             a7,
+                             a8,
+                             a9,
+                             make_box<obj::native_vector_sequence>(std::move(packed)));
         }
       default:
         throw std::runtime_error{ util::format("unsupported arity: {}", 10 + rest->count()) };

--- a/compiler+runtime/src/cpp/jank/runtime/core/call.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/call.cpp
@@ -12,54 +12,54 @@ namespace jank::runtime
 
   object_ref dynamic_call(object_ref const source)
   {
-    auto const arity_flags(source->get_arity_flags());
+    auto const arity_flags(source.get_arity_flags());
 
     switch(arity_flags)
     {
       case mask_variadic_arity(0):
-        return source->call({});
+        return source.call({});
       default:
-        return source->call();
+        return source.call();
     }
   }
 
   object_ref dynamic_call(object_ref const source, object_ref const a1)
   {
-    auto const arity_flags(source->get_arity_flags());
+    auto const arity_flags(source.get_arity_flags());
     auto const mask(extract_variadic_arity_mask(arity_flags));
 
     switch(mask)
     {
       case mask_variadic_arity(0):
-        return source->call(make_box<obj::native_array_sequence>(a1));
+        return source.call(make_box<obj::native_array_sequence>(a1));
       case mask_variadic_arity(1):
         if(!is_variadic_ambiguous(arity_flags))
         {
-          return source->call(a1, {});
+          return source.call(a1, {});
         }
       default:
-        return source->call(a1);
+        return source.call(a1);
     }
   }
 
   object_ref dynamic_call(object_ref const source, object_ref const a1, object_ref const a2)
   {
-    auto const arity_flags(source->get_arity_flags());
+    auto const arity_flags(source.get_arity_flags());
     auto const mask(extract_variadic_arity_mask(arity_flags));
 
     switch(mask)
     {
       case mask_variadic_arity(0):
-        return source->call(make_box<obj::native_array_sequence>(a1, a2));
+        return source.call(make_box<obj::native_array_sequence>(a1, a2));
       case mask_variadic_arity(1):
-        return source->call(a1, make_box<obj::native_array_sequence>(a2));
+        return source.call(a1, make_box<obj::native_array_sequence>(a2));
       case mask_variadic_arity(2):
         if(!is_variadic_ambiguous(arity_flags))
         {
-          return source->call(a1, a2, {});
+          return source.call(a1, a2, {});
         }
       default:
-        return source->call(a1, a2);
+        return source.call(a1, a2);
     }
   }
 
@@ -68,24 +68,24 @@ namespace jank::runtime
                           object_ref const a2,
                           object_ref const a3)
   {
-    auto const arity_flags(source->get_arity_flags());
+    auto const arity_flags(source.get_arity_flags());
     auto const mask(extract_variadic_arity_mask(arity_flags));
 
     switch(mask)
     {
       case mask_variadic_arity(0):
-        return source->call(make_box<obj::native_array_sequence>(a1, a2, a3));
+        return source.call(make_box<obj::native_array_sequence>(a1, a2, a3));
       case mask_variadic_arity(1):
-        return source->call(a1, make_box<obj::native_array_sequence>(a2, a3));
+        return source.call(a1, make_box<obj::native_array_sequence>(a2, a3));
       case mask_variadic_arity(2):
-        return source->call(a1, a2, make_box<obj::native_array_sequence>(a3));
+        return source.call(a1, a2, make_box<obj::native_array_sequence>(a3));
       case mask_variadic_arity(3):
         if(!is_variadic_ambiguous(arity_flags))
         {
-          return source->call(a1, a2, a3, {});
+          return source.call(a1, a2, a3, {});
         }
       default:
-        return source->call(a1, a2, a3);
+        return source.call(a1, a2, a3);
     }
   }
 
@@ -95,26 +95,26 @@ namespace jank::runtime
                           object_ref const a3,
                           object_ref const a4)
   {
-    auto const arity_flags(source->get_arity_flags());
+    auto const arity_flags(source.get_arity_flags());
     auto const mask(extract_variadic_arity_mask(arity_flags));
 
     switch(mask)
     {
       case mask_variadic_arity(0):
-        return source->call(make_box<obj::native_array_sequence>(a1, a2, a3, a4));
+        return source.call(make_box<obj::native_array_sequence>(a1, a2, a3, a4));
       case mask_variadic_arity(1):
-        return source->call(a1, make_box<obj::native_array_sequence>(a2, a3, a4));
+        return source.call(a1, make_box<obj::native_array_sequence>(a2, a3, a4));
       case mask_variadic_arity(2):
-        return source->call(a1, a2, make_box<obj::native_array_sequence>(a3, a4));
+        return source.call(a1, a2, make_box<obj::native_array_sequence>(a3, a4));
       case mask_variadic_arity(3):
-        return source->call(a1, a2, a3, make_box<obj::native_array_sequence>(a4));
+        return source.call(a1, a2, a3, make_box<obj::native_array_sequence>(a4));
       case mask_variadic_arity(4):
         if(!is_variadic_ambiguous(arity_flags))
         {
-          return source->call(a1, a2, a3, a4, {});
+          return source.call(a1, a2, a3, a4, {});
         }
       default:
-        return source->call(a1, a2, a3, a4);
+        return source.call(a1, a2, a3, a4);
     }
   }
 
@@ -125,28 +125,28 @@ namespace jank::runtime
                           object_ref const a4,
                           object_ref const a5)
   {
-    auto const arity_flags(source->get_arity_flags());
+    auto const arity_flags(source.get_arity_flags());
     auto const mask(extract_variadic_arity_mask(arity_flags));
 
     switch(mask)
     {
       case mask_variadic_arity(0):
-        return source->call(make_box<obj::native_array_sequence>(a1, a2, a3, a4, a5));
+        return source.call(make_box<obj::native_array_sequence>(a1, a2, a3, a4, a5));
       case mask_variadic_arity(1):
-        return source->call(a1, make_box<obj::native_array_sequence>(a2, a3, a4, a5));
+        return source.call(a1, make_box<obj::native_array_sequence>(a2, a3, a4, a5));
       case mask_variadic_arity(2):
-        return source->call(a1, a2, make_box<obj::native_array_sequence>(a3, a4, a5));
+        return source.call(a1, a2, make_box<obj::native_array_sequence>(a3, a4, a5));
       case mask_variadic_arity(3):
-        return source->call(a1, a2, a3, make_box<obj::native_array_sequence>(a4, a5));
+        return source.call(a1, a2, a3, make_box<obj::native_array_sequence>(a4, a5));
       case mask_variadic_arity(4):
-        return source->call(a1, a2, a3, a4, make_box<obj::native_array_sequence>(a5));
+        return source.call(a1, a2, a3, a4, make_box<obj::native_array_sequence>(a5));
       case mask_variadic_arity(5):
         if(!is_variadic_ambiguous(arity_flags))
         {
-          return source->call(a1, a2, a3, a4, a5, {});
+          return source.call(a1, a2, a3, a4, a5, {});
         }
       default:
-        return source->call(a1, a2, a3, a4, a5);
+        return source.call(a1, a2, a3, a4, a5);
     }
   }
 
@@ -158,30 +158,30 @@ namespace jank::runtime
                           object_ref const a5,
                           object_ref const a6)
   {
-    auto const arity_flags(source->get_arity_flags());
+    auto const arity_flags(source.get_arity_flags());
     auto const mask(extract_variadic_arity_mask(arity_flags));
 
     switch(mask)
     {
       case mask_variadic_arity(0):
-        return source->call(make_box<obj::native_array_sequence>(a1, a2, a3, a4, a5, a6));
+        return source.call(make_box<obj::native_array_sequence>(a1, a2, a3, a4, a5, a6));
       case mask_variadic_arity(1):
-        return source->call(a1, make_box<obj::native_array_sequence>(a2, a3, a4, a5, a6));
+        return source.call(a1, make_box<obj::native_array_sequence>(a2, a3, a4, a5, a6));
       case mask_variadic_arity(2):
-        return source->call(a1, a2, make_box<obj::native_array_sequence>(a3, a4, a5, a6));
+        return source.call(a1, a2, make_box<obj::native_array_sequence>(a3, a4, a5, a6));
       case mask_variadic_arity(3):
-        return source->call(a1, a2, a3, make_box<obj::native_array_sequence>(a4, a5, a6));
+        return source.call(a1, a2, a3, make_box<obj::native_array_sequence>(a4, a5, a6));
       case mask_variadic_arity(4):
-        return source->call(a1, a2, a3, a4, make_box<obj::native_array_sequence>(a5, a6));
+        return source.call(a1, a2, a3, a4, make_box<obj::native_array_sequence>(a5, a6));
       case mask_variadic_arity(5):
-        return source->call(a1, a2, a3, a4, a5, make_box<obj::native_array_sequence>(a6));
+        return source.call(a1, a2, a3, a4, a5, make_box<obj::native_array_sequence>(a6));
       case mask_variadic_arity(6):
         if(!is_variadic_ambiguous(arity_flags))
         {
-          return source->call(a1, a2, a3, a4, a5, a6, {});
+          return source.call(a1, a2, a3, a4, a5, a6, {});
         }
       default:
-        return source->call(a1, a2, a3, a4, a5, a6);
+        return source.call(a1, a2, a3, a4, a5, a6);
     }
   }
 
@@ -194,32 +194,32 @@ namespace jank::runtime
                           object_ref const a6,
                           object_ref const a7)
   {
-    auto const arity_flags(source->get_arity_flags());
+    auto const arity_flags(source.get_arity_flags());
     auto const mask(extract_variadic_arity_mask(arity_flags));
 
     switch(mask)
     {
       case mask_variadic_arity(0):
-        return source->call(make_box<obj::native_array_sequence>(a1, a2, a3, a4, a5, a6, a7));
+        return source.call(make_box<obj::native_array_sequence>(a1, a2, a3, a4, a5, a6, a7));
       case mask_variadic_arity(1):
-        return source->call(a1, make_box<obj::native_array_sequence>(a2, a3, a4, a5, a6, a7));
+        return source.call(a1, make_box<obj::native_array_sequence>(a2, a3, a4, a5, a6, a7));
       case mask_variadic_arity(2):
-        return source->call(a1, a2, make_box<obj::native_array_sequence>(a3, a4, a5, a6, a7));
+        return source.call(a1, a2, make_box<obj::native_array_sequence>(a3, a4, a5, a6, a7));
       case mask_variadic_arity(3):
-        return source->call(a1, a2, a3, make_box<obj::native_array_sequence>(a4, a5, a6, a7));
+        return source.call(a1, a2, a3, make_box<obj::native_array_sequence>(a4, a5, a6, a7));
       case mask_variadic_arity(4):
-        return source->call(a1, a2, a3, a4, make_box<obj::native_array_sequence>(a5, a6, a7));
+        return source.call(a1, a2, a3, a4, make_box<obj::native_array_sequence>(a5, a6, a7));
       case mask_variadic_arity(5):
-        return source->call(a1, a2, a3, a4, a5, make_box<obj::native_array_sequence>(a6, a7));
+        return source.call(a1, a2, a3, a4, a5, make_box<obj::native_array_sequence>(a6, a7));
       case mask_variadic_arity(6):
-        return source->call(a1, a2, a3, a4, a5, a6, make_box<obj::native_array_sequence>(a7));
+        return source.call(a1, a2, a3, a4, a5, a6, make_box<obj::native_array_sequence>(a7));
       case mask_variadic_arity(7):
         if(!is_variadic_ambiguous(arity_flags))
         {
-          return source->call(a1, a2, a3, a4, a5, a6, a7, {});
+          return source.call(a1, a2, a3, a4, a5, a6, a7, {});
         }
       default:
-        return source->call(a1, a2, a3, a4, a5, a6, a7);
+        return source.call(a1, a2, a3, a4, a5, a6, a7);
     }
   }
 
@@ -233,34 +233,34 @@ namespace jank::runtime
                           object_ref const a7,
                           object_ref const a8)
   {
-    auto const arity_flags(source->get_arity_flags());
+    auto const arity_flags(source.get_arity_flags());
     auto const mask(extract_variadic_arity_mask(arity_flags));
 
     switch(mask)
     {
       case mask_variadic_arity(0):
-        return source->call(make_box<obj::native_array_sequence>(a1, a2, a3, a4, a5, a6, a7, a8));
+        return source.call(make_box<obj::native_array_sequence>(a1, a2, a3, a4, a5, a6, a7, a8));
       case mask_variadic_arity(1):
-        return source->call(a1, make_box<obj::native_array_sequence>(a2, a3, a4, a5, a6, a7, a8));
+        return source.call(a1, make_box<obj::native_array_sequence>(a2, a3, a4, a5, a6, a7, a8));
       case mask_variadic_arity(2):
-        return source->call(a1, a2, make_box<obj::native_array_sequence>(a3, a4, a5, a6, a7, a8));
+        return source.call(a1, a2, make_box<obj::native_array_sequence>(a3, a4, a5, a6, a7, a8));
       case mask_variadic_arity(3):
-        return source->call(a1, a2, a3, make_box<obj::native_array_sequence>(a4, a5, a6, a7, a8));
+        return source.call(a1, a2, a3, make_box<obj::native_array_sequence>(a4, a5, a6, a7, a8));
       case mask_variadic_arity(4):
-        return source->call(a1, a2, a3, a4, make_box<obj::native_array_sequence>(a5, a6, a7, a8));
+        return source.call(a1, a2, a3, a4, make_box<obj::native_array_sequence>(a5, a6, a7, a8));
       case mask_variadic_arity(5):
-        return source->call(a1, a2, a3, a4, a5, make_box<obj::native_array_sequence>(a6, a7, a8));
+        return source.call(a1, a2, a3, a4, a5, make_box<obj::native_array_sequence>(a6, a7, a8));
       case mask_variadic_arity(6):
-        return source->call(a1, a2, a3, a4, a5, a6, make_box<obj::native_array_sequence>(a7, a8));
+        return source.call(a1, a2, a3, a4, a5, a6, make_box<obj::native_array_sequence>(a7, a8));
       case mask_variadic_arity(7):
-        return source->call(a1, a2, a3, a4, a5, a6, a7, make_box<obj::native_array_sequence>(a8));
+        return source.call(a1, a2, a3, a4, a5, a6, a7, make_box<obj::native_array_sequence>(a8));
       case mask_variadic_arity(8):
         if(!is_variadic_ambiguous(arity_flags))
         {
-          return source->call(a1, a2, a3, a4, a5, a6, a7, a8, {});
+          return source.call(a1, a2, a3, a4, a5, a6, a7, a8, {});
         }
       default:
-        return source->call(a1, a2, a3, a4, a5, a6, a7, a8);
+        return source.call(a1, a2, a3, a4, a5, a6, a7, a8);
     }
   }
 
@@ -275,51 +275,51 @@ namespace jank::runtime
                           object_ref const a8,
                           object_ref const a9)
   {
-    auto const arity_flags(source->get_arity_flags());
+    auto const arity_flags(source.get_arity_flags());
     auto const mask(extract_variadic_arity_mask(arity_flags));
 
     switch(mask)
     {
       case mask_variadic_arity(0):
-        return source->call(
+        return source.call(
           make_box<obj::native_array_sequence>(a1, a2, a3, a4, a5, a6, a7, a8, a9));
       case mask_variadic_arity(1):
-        return source->call(a1,
+        return source.call(a1,
                             make_box<obj::native_array_sequence>(a2, a3, a4, a5, a6, a7, a8, a9));
       case mask_variadic_arity(2):
-        return source->call(a1,
+        return source.call(a1,
                             a2,
                             make_box<obj::native_array_sequence>(a3, a4, a5, a6, a7, a8, a9));
       case mask_variadic_arity(3):
-        return source->call(a1,
+        return source.call(a1,
                             a2,
                             a3,
                             make_box<obj::native_array_sequence>(a4, a5, a6, a7, a8, a9));
       case mask_variadic_arity(4):
-        return source->call(a1,
+        return source.call(a1,
                             a2,
                             a3,
                             a4,
                             make_box<obj::native_array_sequence>(a5, a6, a7, a8, a9));
       case mask_variadic_arity(5):
         return source
-          ->call(a1, a2, a3, a4, a5, make_box<obj::native_array_sequence>(a6, a7, a8, a9));
+          .call(a1, a2, a3, a4, a5, make_box<obj::native_array_sequence>(a6, a7, a8, a9));
       case mask_variadic_arity(6):
         return source
-          ->call(a1, a2, a3, a4, a5, a6, make_box<obj::native_array_sequence>(a7, a8, a9));
+          .call(a1, a2, a3, a4, a5, a6, make_box<obj::native_array_sequence>(a7, a8, a9));
       case mask_variadic_arity(7):
         return source
-          ->call(a1, a2, a3, a4, a5, a6, a7, make_box<obj::native_array_sequence>(a8, a9));
+          .call(a1, a2, a3, a4, a5, a6, a7, make_box<obj::native_array_sequence>(a8, a9));
       case mask_variadic_arity(8):
         return source
-          ->call(a1, a2, a3, a4, a5, a6, a7, a8, make_box<obj::native_array_sequence>(a9));
+          .call(a1, a2, a3, a4, a5, a6, a7, a8, make_box<obj::native_array_sequence>(a9));
       case mask_variadic_arity(9):
         if(!is_variadic_ambiguous(arity_flags))
         {
-          return source->call(a1, a2, a3, a4, a5, a6, a7, a8, a9, {});
+          return source.call(a1, a2, a3, a4, a5, a6, a7, a8, a9, {});
         }
       default:
-        return source->call(a1, a2, a3, a4, a5, a6, a7, a8, a9);
+        return source.call(a1, a2, a3, a4, a5, a6, a7, a8, a9);
     }
   }
 
@@ -335,56 +335,56 @@ namespace jank::runtime
                           object_ref const a9,
                           object_ref const a10)
   {
-    auto const arity_flags(source->get_arity_flags());
+    auto const arity_flags(source.get_arity_flags());
     auto const mask(extract_variadic_arity_mask(arity_flags));
 
     switch(mask)
     {
       case mask_variadic_arity(0):
-        return source->call(
+        return source.call(
           make_box<obj::native_array_sequence>(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10));
       case mask_variadic_arity(1):
-        return source->call(
+        return source.call(
           a1,
           make_box<obj::native_array_sequence>(a2, a3, a4, a5, a6, a7, a8, a9, a10));
       case mask_variadic_arity(2):
-        return source->call(a1,
+        return source.call(a1,
                             a2,
                             make_box<obj::native_array_sequence>(a3, a4, a5, a6, a7, a8, a9, a10));
       case mask_variadic_arity(3):
-        return source->call(a1,
+        return source.call(a1,
                             a2,
                             a3,
                             make_box<obj::native_array_sequence>(a4, a5, a6, a7, a8, a9, a10));
       case mask_variadic_arity(4):
-        return source->call(a1,
+        return source.call(a1,
                             a2,
                             a3,
                             a4,
                             make_box<obj::native_array_sequence>(a5, a6, a7, a8, a9, a10));
       case mask_variadic_arity(5):
         return source
-          ->call(a1, a2, a3, a4, a5, make_box<obj::native_array_sequence>(a6, a7, a8, a9, a10));
+          .call(a1, a2, a3, a4, a5, make_box<obj::native_array_sequence>(a6, a7, a8, a9, a10));
       case mask_variadic_arity(6):
         return source
-          ->call(a1, a2, a3, a4, a5, a6, make_box<obj::native_array_sequence>(a7, a8, a9, a10));
+          .call(a1, a2, a3, a4, a5, a6, make_box<obj::native_array_sequence>(a7, a8, a9, a10));
       case mask_variadic_arity(7):
         return source
-          ->call(a1, a2, a3, a4, a5, a6, a7, make_box<obj::native_array_sequence>(a8, a9, a10));
+          .call(a1, a2, a3, a4, a5, a6, a7, make_box<obj::native_array_sequence>(a8, a9, a10));
       case mask_variadic_arity(8):
         return source
-          ->call(a1, a2, a3, a4, a5, a6, a7, a8, make_box<obj::native_array_sequence>(a9, a10));
+          .call(a1, a2, a3, a4, a5, a6, a7, a8, make_box<obj::native_array_sequence>(a9, a10));
       case mask_variadic_arity(9):
         return source
-          ->call(a1, a2, a3, a4, a5, a6, a7, a8, a9, make_box<obj::native_array_sequence>(a10));
+          .call(a1, a2, a3, a4, a5, a6, a7, a8, a9, make_box<obj::native_array_sequence>(a10));
       case mask_variadic_arity(10):
         if(!is_variadic_ambiguous(arity_flags))
         {
           return source
-            ->call(a1, a2, a3, a4, a5, a6, a7, a8, a9, make_box<obj::native_array_sequence>(a10));
+            .call(a1, a2, a3, a4, a5, a6, a7, a8, a9, make_box<obj::native_array_sequence>(a10));
         }
       default:
-        return source->call(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10);
+        return source.call(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10);
     }
   }
 
@@ -401,7 +401,7 @@ namespace jank::runtime
                           object_ref const a10,
                           obj::persistent_list_ref const rest)
   {
-    auto const arity_flags(source->get_arity_flags());
+    auto const arity_flags(source.get_arity_flags());
     auto const mask(extract_variadic_arity_mask(arity_flags));
     switch(mask)
     {
@@ -412,7 +412,7 @@ namespace jank::runtime
           packed.reserve(10 + rest->count());
           packed.insert(packed.end(), { a1, a2, a3, a4, a5, a6, a7, a8, a9, a10 });
           std::copy(rest->data.begin(), rest->data.end(), std::back_inserter(packed));
-          return source->call(make_box<obj::native_vector_sequence>(std::move(packed)));
+          return source.call(make_box<obj::native_vector_sequence>(std::move(packed)));
         }
       case mask_variadic_arity(1):
         {
@@ -420,7 +420,7 @@ namespace jank::runtime
           packed.reserve(9 + rest->count());
           packed.insert(packed.end(), { a2, a3, a4, a5, a6, a7, a8, a9, a10 });
           std::copy(rest->data.begin(), rest->data.end(), std::back_inserter(packed));
-          return source->call(a1, make_box<obj::native_vector_sequence>(std::move(packed)));
+          return source.call(a1, make_box<obj::native_vector_sequence>(std::move(packed)));
         }
       case mask_variadic_arity(2):
         {
@@ -428,7 +428,7 @@ namespace jank::runtime
           packed.reserve(8 + rest->count());
           packed.insert(packed.end(), { a3, a4, a5, a6, a7, a8, a9, a10 });
           std::copy(rest->data.begin(), rest->data.end(), std::back_inserter(packed));
-          return source->call(a1, a2, make_box<obj::native_vector_sequence>(std::move(packed)));
+          return source.call(a1, a2, make_box<obj::native_vector_sequence>(std::move(packed)));
         }
       case mask_variadic_arity(3):
         {
@@ -436,7 +436,7 @@ namespace jank::runtime
           packed.reserve(7 + rest->count());
           packed.insert(packed.end(), { a4, a5, a6, a7, a8, a9, a10 });
           std::copy(rest->data.begin(), rest->data.end(), std::back_inserter(packed));
-          return source->call(a1, a2, a3, make_box<obj::native_vector_sequence>(std::move(packed)));
+          return source.call(a1, a2, a3, make_box<obj::native_vector_sequence>(std::move(packed)));
         }
       case mask_variadic_arity(4):
         {
@@ -444,7 +444,7 @@ namespace jank::runtime
           packed.reserve(6 + rest->count());
           packed.insert(packed.end(), { a5, a6, a7, a8, a9, a10 });
           std::copy(rest->data.begin(), rest->data.end(), std::back_inserter(packed));
-          return source->call(a1,
+          return source.call(a1,
                               a2,
                               a3,
                               a4,
@@ -457,7 +457,7 @@ namespace jank::runtime
           packed.insert(packed.end(), { a6, a7, a8, a9, a10 });
           std::copy(rest->data.begin(), rest->data.end(), std::back_inserter(packed));
           return source
-            ->call(a1, a2, a3, a4, a5, make_box<obj::native_vector_sequence>(std::move(packed)));
+            .call(a1, a2, a3, a4, a5, make_box<obj::native_vector_sequence>(std::move(packed)));
         }
       case mask_variadic_arity(6):
         {
@@ -465,7 +465,7 @@ namespace jank::runtime
           packed.reserve(4 + rest->count());
           packed.insert(packed.end(), { a7, a8, a9, a10 });
           std::copy(rest->data.begin(), rest->data.end(), std::back_inserter(packed));
-          return source->call(a1,
+          return source.call(a1,
                               a2,
                               a3,
                               a4,
@@ -479,7 +479,7 @@ namespace jank::runtime
           packed.reserve(3 + rest->count());
           packed.insert(packed.end(), { a8, a9, a10 });
           std::copy(rest->data.begin(), rest->data.end(), std::back_inserter(packed));
-          return source->call(a1,
+          return source.call(a1,
                               a2,
                               a3,
                               a4,
@@ -494,7 +494,7 @@ namespace jank::runtime
           packed.reserve(2 + rest->count());
           packed.insert(packed.end(), { a9, a10 });
           std::copy(rest->data.begin(), rest->data.end(), std::back_inserter(packed));
-          return source->call(a1,
+          return source.call(a1,
                               a2,
                               a3,
                               a4,
@@ -510,7 +510,7 @@ namespace jank::runtime
           packed.reserve(1 + rest->count());
           packed.insert(packed.end(), { a10 });
           std::copy(rest->data.begin(), rest->data.end(), std::back_inserter(packed));
-          return source->call(a1,
+          return source.call(a1,
                               a2,
                               a3,
                               a4,

--- a/compiler+runtime/src/cpp/jank/runtime/core/equal.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/equal.cpp
@@ -1,13 +1,13 @@
 #include <jank/runtime/core/equal.hpp>
 #include <jank/runtime/behavior/comparable.hpp>
 #include <jank/runtime/visit.hpp>
-#include <jank/util/fmt.hpp>
+#include <jank/util/fmt/print.hpp>
 
 namespace jank::runtime
 {
   bool equal(char const lhs, object_ref const rhs)
   {
-    if(rhs.is_nil() || rhs->type != object_type::character)
+    if(rhs.is_nil() || rhs.get_type() != object_type::character)
     {
       return false;
     }
@@ -27,7 +27,7 @@ namespace jank::runtime
       return false;
     }
 
-    return visit_object([&](auto const typed_lhs) { return typed_lhs->equal(*rhs); }, lhs);
+    return visit_object([&](auto const typed_lhs) { return typed_lhs.equal(rhs); }, lhs);
   }
 
   i64 compare(object_ref const l, object_ref const r)
@@ -44,20 +44,7 @@ namespace jank::runtime
         return 1;
       }
 
-      return visit_object(
-        [](auto const typed_l, auto const &r) -> i64 {
-          using L = typename jtl::decay_t<decltype(typed_l)>::value_type;
-          if constexpr(behavior::comparable<L>)
-          {
-            return typed_l->compare(*r);
-          }
-          else
-          {
-            throw std::runtime_error{ util::format("not comparable: {}", typed_l->to_string()) };
-          }
-        },
-        l,
-        r);
+      return l.compare(r);
     }
 
     return -1;

--- a/compiler+runtime/src/cpp/jank/runtime/core/math.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/math.cpp
@@ -35,6 +35,22 @@ namespace jank::runtime
     }
   }
 
+  i64 to_i64(object_ref const o)
+  {
+    if(detail::is_small_int(o.data))
+    {
+      return detail::as_int(o.data);
+    }
+
+    if(auto const i{ dyn_cast<obj::integer>(o) }; i.is_some())
+    {
+      return i->data;
+    }
+
+    throw std::runtime_error{ util::format("An integer was required here, but a {} was provided.",
+                                           object_type_str(o.get_type())) };
+  }
+
   object_ref promoting_add(object_ref const l, object_ref const r)
   {
     return visit_number_like(
@@ -45,7 +61,8 @@ namespace jank::runtime
           [](auto const typed_r, auto const &l_val) -> object_ref {
             using RT = typename decltype(typed_r)::value_type;
 
-            if constexpr(std::same_as<LT, obj::integer> && std::same_as<RT, obj::integer>)
+            if constexpr(jtl::is_any_same<LT, obj::integer, obj::small_integer>
+                         && jtl::is_any_same<RT, obj::integer, obj::small_integer>)
             {
               i64 res{};
 
@@ -55,7 +72,7 @@ namespace jank::runtime
                 return make_box<obj::big_integer>(l + typed_r->data);
               }
 
-              return make_box<obj::integer>(res);
+              return make_box(res);
             }
             else
             {
@@ -79,7 +96,8 @@ namespace jank::runtime
           [](auto const typed_r, auto const &l_val) -> object_ref {
             using RT = typename decltype(typed_r)::value_type;
 
-            if constexpr(std::same_as<LT, obj::integer> && std::same_as<RT, obj::integer>)
+            if constexpr(jtl::is_any_same<LT, obj::integer, obj::small_integer>
+                         && jtl::is_any_same<RT, obj::integer, obj::small_integer>)
             {
               i64 res{};
 
@@ -89,7 +107,7 @@ namespace jank::runtime
                 return make_box<obj::big_integer>(l_val - typed_r->data);
               }
 
-              return make_box<obj::integer>(res);
+              return make_box(res);
             }
             else
             {
@@ -298,7 +316,8 @@ namespace jank::runtime
           [](auto const typed_r, auto const &l_val) -> object_ref {
             using RT = typename decltype(typed_r)::value_type;
 
-            if constexpr(std::same_as<LT, obj::integer> && std::same_as<RT, obj::integer>)
+            if constexpr(jtl::is_any_same<LT, obj::integer, obj::small_integer>
+                         && jtl::is_any_same<RT, obj::integer, obj::small_integer>)
             {
               i64 res{};
 
@@ -308,7 +327,7 @@ namespace jank::runtime
                 return make_box<obj::big_integer>(l * typed_r->data);
               }
 
-              return make_box<obj::integer>(res);
+              return make_box(res);
             }
             else
             {
@@ -411,7 +430,7 @@ namespace jank::runtime
       [](auto const typed_l) -> object_ref {
         using T = typename decltype(typed_l)::value_type;
 
-        if constexpr(std::same_as<T, obj::integer>)
+        if constexpr(jtl::is_any_same<T, obj::integer, obj::small_integer>)
         {
           i64 res{};
 
@@ -421,7 +440,7 @@ namespace jank::runtime
             return make_box<obj::big_integer>(v + 1ll);
           }
 
-          return make_box<obj::integer>(res);
+          return make_box(res);
         }
         else
         {
@@ -444,7 +463,7 @@ namespace jank::runtime
       [](auto const typed_l) -> object_ref {
         using T = typename decltype(typed_l)::value_type;
 
-        if constexpr(std::same_as<T, obj::integer>)
+        if constexpr(jtl::is_any_same<T, obj::integer, obj::small_integer>)
         {
           i64 res{};
 
@@ -454,7 +473,7 @@ namespace jank::runtime
             return make_box<obj::big_integer>(v - 1ll);
           }
 
-          return make_box<obj::integer>(res);
+          return make_box(res);
         }
         else
         {
@@ -508,34 +527,22 @@ namespace jank::runtime
 
   bool is_even(object_ref const l)
   {
-    if(l->type == object_type::integer)
-    {
-      return expect_object<obj::integer>(l)->data % 2 == 0;
-    }
-
-    if(l->type == object_type::big_integer)
+    if(l.get_type() == object_type::big_integer)
     {
       return expect_object<obj::big_integer>(l)->data % 2 == 0;
     }
 
-    throw make_box(util::format("Argument must be an integer: {}", object_type_str(l->type)))
-      .erase();
+    return to_i64(l) % 2 == 0;
   }
 
   bool is_odd(object_ref const l)
   {
-    if(l->type == object_type::integer)
-    {
-      return expect_object<obj::integer>(l)->data % 2 != 0;
-    }
-
-    if(l->type == object_type::big_integer)
+    if(l.get_type() == object_type::big_integer)
     {
       return expect_object<obj::big_integer>(l)->data % 2 != 0;
     }
 
-    throw make_box(util::format("Argument must be an integer: {}", object_type_str(l->type)))
-      .erase();
+    return to_i64(l) % 2 != 0;
   }
 
   bool is_equiv(object_ref const l, object_ref const r)
@@ -563,182 +570,96 @@ namespace jank::runtime
 
   i64 bit_not(object_ref const l)
   {
-    auto const typed_l{ dyn_cast<obj::integer>(l) };
-
-    if(typed_l.is_nil())
-    {
-      throw std::runtime_error{
-        "Bitwise operators are only supported for values of type integer."
-      };
-    }
-
-    return ~typed_l->data;
+    auto const l_data{ to_i64(l) };
+    return ~l_data;
   }
 
   i64 bit_and(object_ref const l, object_ref const r)
   {
-    auto const typed_l{ dyn_cast<obj::integer>(l) };
-    auto const typed_r{ dyn_cast<obj::integer>(r) };
+    auto const l_data{ to_i64(l) };
+    auto const r_data{ to_i64(r) };
 
-    if(typed_l.is_nil() || typed_r.is_nil())
-    {
-      throw std::runtime_error{
-        "Bitwise operators are only supported for values of type integer."
-      };
-    }
-
-    return typed_l->data & typed_r->data;
+    return l_data & r_data;
   }
 
   i64 bit_or(object_ref const l, object_ref const r)
   {
-    auto const typed_l{ dyn_cast<obj::integer>(l) };
-    auto const typed_r{ dyn_cast<obj::integer>(r) };
+    auto const l_data{ to_i64(l) };
+    auto const r_data{ to_i64(r) };
 
-    if(typed_l.is_nil() || typed_r.is_nil())
-    {
-      throw std::runtime_error{
-        "Bitwise operators are only supported for values of type integer."
-      };
-    }
-
-    return typed_l->data | typed_r->data;
+    return l_data | r_data;
   }
 
   i64 bit_xor(object_ref const l, object_ref const r)
   {
-    auto const typed_l{ dyn_cast<obj::integer>(l) };
-    auto const typed_r{ dyn_cast<obj::integer>(r) };
+    auto const l_data{ to_i64(l) };
+    auto const r_data{ to_i64(r) };
 
-    if(typed_l.is_nil() || typed_r.is_nil())
-    {
-      throw std::runtime_error{
-        "Bitwise operators are only supported for values of type integer."
-      };
-    }
-
-    return typed_l->data ^ typed_r->data;
+    return l_data ^ r_data;
   }
 
   i64 bit_and_not(object_ref const l, object_ref const r)
   {
-    auto const typed_l{ dyn_cast<obj::integer>(l) };
-    auto const typed_r{ dyn_cast<obj::integer>(r) };
+    auto const l_data{ to_i64(l) };
+    auto const r_data{ to_i64(r) };
 
-    if(typed_l.is_nil() || typed_r.is_nil())
-    {
-      throw std::runtime_error{
-        "Bitwise operators are only supported for values of type integer."
-      };
-    }
-
-    return typed_l->data & (~typed_r->data);
+    return l_data & (~r_data);
   }
 
   i64 bit_clear(object_ref const l, object_ref const r)
   {
-    auto const typed_l{ dyn_cast<obj::integer>(l) };
-    auto const typed_r{ dyn_cast<obj::integer>(r) };
+    auto const l_data{ to_i64(l) };
+    auto const r_data{ to_i64(r) };
 
-    if(typed_l.is_nil() || typed_r.is_nil())
-    {
-      throw std::runtime_error{
-        "Bitwise operators are only supported for values of type integer."
-      };
-    }
-
-    return typed_l->data & ~(static_cast<i64>(1) << typed_r->data);
+    return l_data & ~(static_cast<i64>(1) << r_data);
   }
 
   i64 bit_set(object_ref const l, object_ref const r)
   {
-    auto const typed_l{ dyn_cast<obj::integer>(l) };
-    auto const typed_r{ dyn_cast<obj::integer>(r) };
+    auto const l_data{ to_i64(l) };
+    auto const r_data{ to_i64(r) };
 
-    if(typed_l.is_nil() || typed_r.is_nil())
-    {
-      throw std::runtime_error{
-        "Bitwise operators are only supported for values of type integer."
-      };
-    }
-
-    return typed_l->data | (static_cast<i64>(1) << typed_r->data);
+    return l_data | (static_cast<i64>(1) << r_data);
   }
 
   i64 bit_flip(object_ref const l, object_ref const r)
   {
-    auto const typed_l{ dyn_cast<obj::integer>(l) };
-    auto const typed_r{ dyn_cast<obj::integer>(r) };
+    auto const l_data{ to_i64(l) };
+    auto const r_data{ to_i64(r) };
 
-    if(typed_l.is_nil() || typed_r.is_nil())
-    {
-      throw std::runtime_error{
-        "Bitwise operators are only supported for values of type integer."
-      };
-    }
-
-    return typed_l->data ^ (static_cast<i64>(1) << typed_r->data);
+    return l_data ^ (static_cast<i64>(1) << r_data);
   }
 
   bool bit_test(object_ref const l, object_ref const r)
   {
-    auto const typed_l{ dyn_cast<obj::integer>(l) };
-    auto const typed_r{ dyn_cast<obj::integer>(r) };
+    auto const l_data{ to_i64(l) };
+    auto const r_data{ to_i64(r) };
 
-    if(typed_l.is_nil() || typed_r.is_nil())
-    {
-      throw std::runtime_error{
-        "Bitwise operators are only supported for values of type integer."
-      };
-    }
-
-    return (typed_l->data >> typed_r->data) & static_cast<i64>(1);
+    return (l_data >> r_data) & static_cast<i64>(1);
   }
 
   i64 bit_shift_left(object_ref const l, object_ref const r)
   {
-    auto const typed_l{ dyn_cast<obj::integer>(l) };
-    auto const typed_r{ dyn_cast<obj::integer>(r) };
+    auto const l_data{ to_i64(l) };
+    auto const r_data{ to_i64(r) };
 
-    if(typed_l.is_nil() || typed_r.is_nil())
-    {
-      throw std::runtime_error{
-        "Bitwise operators are only supported for values of type integer."
-      };
-    }
-
-    return typed_l->data << typed_r->data;
+    return l_data << r_data;
   }
 
   i64 bit_shift_right(object_ref const l, object_ref const r)
   {
-    auto const typed_l{ dyn_cast<obj::integer>(l) };
-    auto const typed_r{ dyn_cast<obj::integer>(r) };
+    auto const l_data{ to_i64(l) };
+    auto const r_data{ to_i64(r) };
 
-    if(typed_l.is_nil() || typed_r.is_nil())
-    {
-      throw std::runtime_error{
-        "Bitwise operators are only supported for values of type integer."
-      };
-    }
-
-    return typed_l->data >> typed_r->data;
+    return l_data >> r_data;
   }
 
   i64 bit_unsigned_shift_right(object_ref const l, object_ref const r)
   {
-    auto const typed_l{ dyn_cast<obj::integer>(l) };
-    auto const typed_r{ dyn_cast<obj::integer>(r) };
+    auto const l_data{ to_i64(l) };
+    auto const r_data{ to_i64(r) };
 
-    if(typed_l.is_nil() || typed_r.is_nil())
-    {
-      throw std::runtime_error{
-        "Bitwise operators are only supported for values of type integer."
-      };
-    }
-
-    using uni = std::make_unsigned_t<i64>;
-    return static_cast<i64>(static_cast<uni>(typed_l->data) >> static_cast<uni>(typed_r->data));
+    return static_cast<i64>(static_cast<u64>(l_data) >> static_cast<u64>(r_data));
   }
 
   f64 rand()
@@ -1062,22 +983,22 @@ namespace jank::runtime
 
   bool is_integer(object_ref const o)
   {
-    return o->type == object_type::integer;
+    return detail::is_small_int(o.data) || o.get_type() == object_type::integer;
   }
 
   bool is_real(object_ref const o)
   {
-    return o->type == object_type::real;
+    return o.get_type() == object_type::real;
   }
 
   bool is_ratio(object_ref const o)
   {
-    return o->type == object_type::ratio;
+    return o.get_type() == object_type::ratio;
   }
 
   bool is_boolean(object_ref const o)
   {
-    return o->type == object_type::boolean;
+    return o.get_type() == object_type::boolean;
   }
 
   bool is_nan(object_ref const o)
@@ -1126,7 +1047,8 @@ namespace jank::runtime
     }
     else
     {
-      throw make_box(util::format("Expected string, got {}", object_type_str(o->type))).erase();
+      throw make_box(util::format("Expected string, got {}", object_type_str(o.get_type())))
+        .erase();
     }
   }
 
@@ -1139,13 +1061,14 @@ namespace jank::runtime
     }
     else
     {
-      throw make_box(util::format("Expected string, got {}", object_type_str(o->type))).erase();
+      throw make_box(util::format("Expected string, got {}", object_type_str(o.get_type())))
+        .erase();
     }
   }
 
   bool is_big_integer(object_ref const o)
   {
-    return o->type == object_type::big_integer;
+    return o.get_type() == object_type::big_integer;
   }
 
   obj::big_integer_ref to_big_integer(object_ref const o)
@@ -1158,18 +1081,21 @@ namespace jank::runtime
         {
           return typed_o;
         }
-        else if constexpr(std::same_as<T, obj::integer> || std::same_as<T, obj::persistent_string>)
+        else if constexpr(jtl::is_any_same<T,
+                                           obj::integer,
+                                           obj::small_integer,
+                                           obj::persistent_string>)
         {
           return make_box<obj::big_integer>(typed_o->data);
         }
-        else if constexpr(std::same_as<T, obj::real> || std::same_as<T, obj::ratio>
-                          || std::same_as<T, obj::big_decimal>)
+        else if constexpr(jtl::is_any_same<T, obj::real, obj::ratio, obj::big_decimal>)
         {
           return make_box<obj::big_integer>(typed_o->to_integer());
         }
         else
         {
-          throw make_box(util::format("Expected a numeric value, got {}", object_type_str(o->type)))
+          throw make_box(
+            util::format("Expected a numeric value, got {}", object_type_str(o.get_type())))
             .erase();
         }
       },
@@ -1178,7 +1104,7 @@ namespace jank::runtime
 
   bool is_big_decimal(object_ref const o)
   {
-    return o->type == object_type::big_decimal;
+    return o.get_type() == object_type::big_decimal;
   }
 
   obj::big_decimal_ref to_big_decimal(object_ref const o)
@@ -1187,12 +1113,12 @@ namespace jank::runtime
       [&](auto const typed_o) -> obj::big_decimal_ref {
         using T = typename jtl::decay_t<decltype(typed_o)>::value_type;
 
-        if constexpr(std::same_as<T, obj::integer>)
+        if constexpr(jtl::is_any_same<T, obj::integer, obj::small_integer>)
         {
           return make_box<obj::big_decimal>(typed_o->to_real());
         }
-        else if constexpr(std::same_as<T, obj::big_integer> || std::same_as<T, obj::real>
-                          || std::same_as<T, obj::ratio> || std::same_as<T, obj::persistent_string>)
+        else if constexpr(
+          jtl::is_any_same<T, obj::big_integer, obj::real, obj::ratio, obj::persistent_string>)
         {
           return make_box<obj::big_decimal>(typed_o->data);
         }
@@ -1202,7 +1128,8 @@ namespace jank::runtime
         }
         else
         {
-          throw make_box(util::format("Expected a numeric value, got {}", object_type_str(o->type)))
+          throw make_box(
+            util::format("Expected a numeric value, got {}", object_type_str(o.get_type())))
             .erase();
         }
       },

--- a/compiler+runtime/src/cpp/jank/runtime/core/meta.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/meta.cpp
@@ -48,7 +48,7 @@ namespace jank::runtime
           throw error::runtime_non_metadatable_value(
             util::format("{} [{}] can't hold any metadata.",
                          typed_o->to_code_string(),
-                         object_type_str(o->type)),
+                         object_type_str(o.get_type())),
             object_source(o));
         }
       },
@@ -103,7 +103,7 @@ namespace jank::runtime
         {
           throw std::runtime_error{ util::format("not metadatable: {} [{}]",
                                                  typed_o->to_code_string(),
-                                                 object_type_str(typed_o->type)) };
+                                                 object_type_str(typed_o.get_type())) };
         }
       },
       o,

--- a/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
@@ -44,7 +44,7 @@ namespace jank::runtime
         else
         {
           throw std::runtime_error{ util::format("cannot check if this is empty: {}",
-                                                 typed_o->to_code_string()) };
+                                                 typed_o.to_code_string()) };
         }
       },
       o);
@@ -94,19 +94,19 @@ namespace jank::runtime
   {
     /* TODO: Visit and use a behavior for this check instead.
      * It should apply to conses and others. */
-    return o->type == object_type::persistent_list;
+    return o.get_type() == object_type::persistent_list;
   }
 
   bool is_vector(object_ref const o)
   {
-    return o->type == object_type::persistent_vector;
+    return o.get_type() == object_type::persistent_vector;
   }
 
   bool is_map(object_ref const o)
   {
-    return (o->type == object_type::persistent_hash_map
-            || o->type == object_type::persistent_array_map
-            || o->type == object_type::persistent_sorted_map);
+    return (o.get_type() == object_type::persistent_hash_map
+            || o.get_type() == object_type::persistent_array_map
+            || o.get_type() == object_type::persistent_sorted_map);
   }
 
   bool is_associative(object_ref const o)
@@ -115,15 +115,15 @@ namespace jank::runtime
       [=](auto const typed_o) -> bool {
         using T = typename jtl::decay_t<decltype(typed_o)>::value_type;
 
-        return (typed_o->has_behavior(object_behavior::get) && behavior::associatively_writable<T>);
+        return (typed_o.has_behavior(object_behavior::get) && behavior::associatively_writable<T>);
       },
       o);
   }
 
   bool is_set(object_ref const o)
   {
-    return (o->type == object_type::persistent_hash_set
-            || o->type == object_type::persistent_sorted_set);
+    return (o.get_type() == object_type::persistent_hash_set
+            || o.get_type() == object_type::persistent_sorted_set);
   }
 
   bool is_counted(object_ref const o)
@@ -150,8 +150,8 @@ namespace jank::runtime
 
   bool is_sorted(object_ref const o)
   {
-    return o->type == object_type::persistent_sorted_map
-      || o->type == object_type::persistent_sorted_set;
+    return o.get_type() == object_type::persistent_sorted_map
+      || o.get_type() == object_type::persistent_sorted_set;
   }
 
   object_ref transient(object_ref const o)
@@ -167,7 +167,7 @@ namespace jank::runtime
         else
         {
           throw std::runtime_error{ util::format("not transientable: {}",
-                                                 typed_o->to_code_string()) };
+                                                 typed_o.to_code_string()) };
         }
       },
       o);
@@ -186,7 +186,7 @@ namespace jank::runtime
         else
         {
           throw std::runtime_error{ util::format("not persistentable: {}",
-                                                 typed_o->to_code_string()) };
+                                                 typed_o.to_code_string()) };
         }
       },
       o);
@@ -205,7 +205,7 @@ namespace jank::runtime
         else
         {
           throw std::runtime_error{ util::format("not conjable_in_place: {}",
-                                                 typed_coll->to_code_string()) };
+                                                 typed_coll.to_code_string()) };
         }
       },
       coll,
@@ -215,15 +215,15 @@ namespace jank::runtime
   object_ref disj_in_place(object_ref const coll, object_ref const o)
   {
     /* TODO: disjoinable_in_place */
-    if(coll->type == object_type::transient_hash_set)
+    if(coll.get_type() == object_type::transient_hash_set)
     {
       return expect_object<obj::transient_hash_set>(coll)->disjoin_in_place(o);
     }
-    else if(coll->type == object_type::transient_array_map)
+    else if(coll.get_type() == object_type::transient_array_map)
     {
       return expect_object<obj::transient_array_map>(coll)->dissoc_in_place(o);
     }
-    else if(coll->type == object_type::transient_sorted_set)
+    else if(coll.get_type() == object_type::transient_sorted_set)
     {
       return expect_object<obj::transient_sorted_set>(coll)->disjoin_in_place(o);
     }
@@ -245,7 +245,7 @@ namespace jank::runtime
         else
         {
           throw std::runtime_error{ util::format("not associatively_writable_in_place: {}",
-                                                 typed_coll->to_code_string()) };
+                                                 typed_coll.to_code_string()) };
         }
       },
       coll,
@@ -266,7 +266,7 @@ namespace jank::runtime
         else
         {
           throw std::runtime_error{ util::format("not associatively_writable_in_place: {}",
-                                                 typed_coll->to_code_string()) };
+                                                 typed_coll.to_code_string()) };
         }
       },
       coll,
@@ -301,7 +301,7 @@ namespace jank::runtime
         }
         else
         {
-          throw std::runtime_error{ util::format("not seqable: {}", typed_s->to_code_string()) };
+          throw std::runtime_error{ util::format("not seqable: {}", typed_s.to_code_string()) };
         }
       },
       s);
@@ -329,7 +329,7 @@ namespace jank::runtime
         }
         else
         {
-          throw std::runtime_error{ util::format("not seqable: {}", typed_s->to_code_string()) };
+          throw std::runtime_error{ util::format("not seqable: {}", typed_s.to_code_string()) };
         }
       },
       s);
@@ -361,7 +361,7 @@ namespace jank::runtime
         }
         else
         {
-          throw std::runtime_error{ util::format("not seqable: {}", typed_s->to_code_string()) };
+          throw std::runtime_error{ util::format("not seqable: {}", typed_s.to_code_string()) };
         }
       },
       s);
@@ -398,7 +398,7 @@ namespace jank::runtime
         }
         else
         {
-          throw std::runtime_error{ util::format("not seqable: {}", typed_s->to_code_string()) };
+          throw std::runtime_error{ util::format("not seqable: {}", typed_s.to_code_string()) };
         }
       },
       s);
@@ -434,7 +434,7 @@ namespace jank::runtime
         }
         else
         {
-          throw std::runtime_error{ util::format("not seqable: {}", typed_s->to_code_string()) };
+          throw std::runtime_error{ util::format("not seqable: {}", typed_s.to_code_string()) };
         }
       },
       s);
@@ -504,7 +504,7 @@ namespace jank::runtime
         }
         else
         {
-          throw std::runtime_error{ util::format("not conjable: {}", typed_s->to_code_string()) };
+          throw std::runtime_error{ util::format("not conjable: {}", typed_s.to_code_string()) };
         }
       },
       s);
@@ -512,11 +512,11 @@ namespace jank::runtime
 
   object_ref disj(object_ref const s, object_ref const o)
   {
-    if(s->type == object_type::nil)
+    if(s.get_type() == object_type::nil)
     {
       return s;
     }
-    else if(s->type == object_type::persistent_hash_set)
+    else if(s.get_type() == object_type::persistent_hash_set)
     {
       auto const set(expect_object<obj::persistent_hash_set>(s));
       return set->disj(o);
@@ -540,7 +540,7 @@ namespace jank::runtime
         else
         {
           throw std::runtime_error{ util::format("not associatively writable: {}",
-                                                 typed_m->to_code_string()) };
+                                                 typed_m.to_code_string()) };
         }
       },
       m);
@@ -559,7 +559,7 @@ namespace jank::runtime
         else
         {
           throw std::runtime_error{ util::format("not associatively writable: {}",
-                                                 typed_m->to_code_string()) };
+                                                 typed_m.to_code_string()) };
         }
       },
       m);
@@ -567,17 +567,17 @@ namespace jank::runtime
 
   object_ref get(object_ref const m, object_ref const key)
   {
-    return m->get(key);
+    return m.get(key);
   }
 
   object_ref get(object_ref const m, object_ref const key, object_ref const fallback)
   {
-    return m->get(key, fallback);
+    return m.get(key, fallback);
   }
 
   object_ref get_in(object_ref const m, object_ref const keys)
   {
-    if(m->has_behavior(object_behavior::get))
+    if(m.has_behavior(object_behavior::get))
     {
       return visit_seqable(
         [&](auto const typed_keys) -> object_ref {
@@ -598,7 +598,7 @@ namespace jank::runtime
 
   object_ref get_in(object_ref const m, object_ref const keys, object_ref const fallback)
   {
-    if(m->has_behavior(object_behavior::get))
+    if(m.has_behavior(object_behavior::get))
     {
       return visit_seqable(
         [&](auto const typed_keys) -> object_ref {
@@ -624,7 +624,7 @@ namespace jank::runtime
 
   object_ref find(object_ref const s, object_ref const key)
   {
-    return s->find(key);
+    return s.find(key);
   }
 
   bool contains(object_ref const s, object_ref const key)
@@ -634,9 +634,9 @@ namespace jank::runtime
       return false;
     }
 
-    if(s->has_behavior(object_behavior::get))
+    if(s.has_behavior(object_behavior::get))
     {
-      return s->contains(key);
+      return s.contains(key);
     }
     else
     {
@@ -674,7 +674,7 @@ namespace jank::runtime
         else
         {
           throw std::runtime_error{ util::format("not associatively_writable: {}",
-                                                 typed_m->to_string()) };
+                                                 typed_m.to_string()) };
         }
       },
       m,
@@ -710,7 +710,7 @@ namespace jank::runtime
         else
         {
           throw std::runtime_error{ util::format("not associatively_writable_in_place: {}",
-                                                 typed_m->to_string()) };
+                                                 typed_m.to_string()) };
         }
       },
       m,
@@ -719,7 +719,7 @@ namespace jank::runtime
 
   object_ref subvec(object_ref const o, i64 const start, i64 const end)
   {
-    if(o->type != object_type::persistent_vector)
+    if(o.get_type() != object_type::persistent_vector)
     {
       throw std::runtime_error{ "not a vector" };
     }
@@ -773,7 +773,7 @@ namespace jank::runtime
         }
         else
         {
-          throw std::runtime_error{ util::format("not indexable: {}", object_type_str(o->type)) };
+          throw std::runtime_error{ util::format("not indexable: {}", object_type_str(o.get_type())) };
         }
       },
       o);
@@ -810,7 +810,7 @@ namespace jank::runtime
         }
         else
         {
-          throw std::runtime_error{ util::format("not indexable: {}", object_type_str(o->type)) };
+          throw std::runtime_error{ util::format("not indexable: {}", object_type_str(o.get_type())) };
         }
       },
       o);
@@ -833,7 +833,7 @@ namespace jank::runtime
         }
         else
         {
-          throw std::runtime_error{ util::format("not stackable: {}", object_type_str(o->type)) };
+          throw std::runtime_error{ util::format("not stackable: {}", object_type_str(o.get_type())) };
         }
       },
       o);
@@ -856,7 +856,7 @@ namespace jank::runtime
         }
         else
         {
-          throw std::runtime_error{ util::format("not stackable: {}", object_type_str(o->type)) };
+          throw std::runtime_error{ util::format("not stackable: {}", object_type_str(o.get_type())) };
         }
       },
       o);
@@ -964,7 +964,7 @@ namespace jank::runtime
         }
         else
         {
-          throw std::runtime_error{ util::format("not seqable: {}", typed_s->to_code_string()) };
+          throw std::runtime_error{ util::format("not seqable: {}", typed_s.to_code_string()) };
         }
       },
       s);
@@ -1011,7 +1011,7 @@ namespace jank::runtime
         for(auto const &e : make_sequence_range(typed_coll))
         {
           res = dynamic_call(f, res, e);
-          if(res->type == object_type::reduced)
+          if(res.get_type() == object_type::reduced)
           {
             res = expect_object<obj::reduced>(res)->val;
             break;
@@ -1031,7 +1031,7 @@ namespace jank::runtime
 
   bool is_reduced(object_ref const o)
   {
-    return o->type == object_type::reduced;
+    return o.get_type() == object_type::reduced;
   }
 
   object_ref chunk_buffer(object_ref const capacity)
@@ -1063,7 +1063,7 @@ namespace jank::runtime
           return typed_o->chunked_first();
         }
         {
-          throw std::runtime_error{ util::format("not chunkable: {}", typed_o->to_code_string()) };
+          throw std::runtime_error{ util::format("not chunkable: {}", typed_o.to_code_string()) };
         }
       },
       o);
@@ -1080,7 +1080,7 @@ namespace jank::runtime
           return typed_o->chunked_next();
         }
         {
-          throw std::runtime_error{ util::format("not chunkable: {}", typed_o->to_code_string()) };
+          throw std::runtime_error{ util::format("not chunkable: {}", typed_o.to_code_string()) };
         }
       },
       o);
@@ -1102,7 +1102,7 @@ namespace jank::runtime
           return ret;
         }
         {
-          throw std::runtime_error{ util::format("not chunkable: {}", typed_o->to_code_string()) };
+          throw std::runtime_error{ util::format("not chunkable: {}", typed_o.to_code_string()) };
         }
       },
       o);

--- a/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/seq.cpp
@@ -773,7 +773,8 @@ namespace jank::runtime
         }
         else
         {
-          throw std::runtime_error{ util::format("not indexable: {}", object_type_str(o.get_type())) };
+          throw std::runtime_error{ util::format("not indexable: {}",
+                                                 object_type_str(o.get_type())) };
         }
       },
       o);
@@ -810,7 +811,8 @@ namespace jank::runtime
         }
         else
         {
-          throw std::runtime_error{ util::format("not indexable: {}", object_type_str(o.get_type())) };
+          throw std::runtime_error{ util::format("not indexable: {}",
+                                                 object_type_str(o.get_type())) };
         }
       },
       o);
@@ -833,7 +835,8 @@ namespace jank::runtime
         }
         else
         {
-          throw std::runtime_error{ util::format("not stackable: {}", object_type_str(o.get_type())) };
+          throw std::runtime_error{ util::format("not stackable: {}",
+                                                 object_type_str(o.get_type())) };
         }
       },
       o);
@@ -856,7 +859,8 @@ namespace jank::runtime
         }
         else
         {
-          throw std::runtime_error{ util::format("not stackable: {}", object_type_str(o.get_type())) };
+          throw std::runtime_error{ util::format("not stackable: {}",
+                                                 object_type_str(o.get_type())) };
         }
       },
       o);

--- a/compiler+runtime/src/cpp/jank/runtime/core/to_string.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/to_string.cpp
@@ -5,7 +5,7 @@ namespace jank::runtime
 {
   jtl::immutable_string to_string(object_ref const o)
   {
-    return visit_object([](auto const typed_o) { return typed_o->to_string(); }, o);
+    return o.to_string();
   }
 
   void to_string(char const ch, jtl::string_builder &buff)
@@ -15,12 +15,12 @@ namespace jank::runtime
 
   void to_string(object_ref const o, jtl::string_builder &buff)
   {
-    visit_object([&](auto const typed_o) { typed_o->to_string(buff); }, o);
+    o.to_string(buff);
   }
 
   jtl::immutable_string to_code_string(object_ref const o)
   {
-    return visit_object([](auto const typed_o) { return typed_o->to_code_string(); }, o);
+    return o.to_code_string();
   }
 
   void to_code_string(char const ch, jtl::string_builder &buff)
@@ -30,8 +30,7 @@ namespace jank::runtime
 
   void to_code_string(object_ref const o, jtl::string_builder &buff)
   {
-    auto const value{ visit_object([](auto const typed_o) { return typed_o->to_code_string(); },
-                                   o) };
+    auto const value{ o.to_code_string() };
     buff(value);
   }
 }

--- a/compiler+runtime/src/cpp/jank/runtime/core/truthy.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core/truthy.cpp
@@ -3,16 +3,16 @@
 
 namespace jank::runtime
 {
-  bool truthy(object const *o)
+  bool truthy(object_ref const o)
   {
-    if(!o)
+    if(o.is_nil())
     {
       return false;
     }
 
-    if(o->type == object_type::nil)
+    if(detail::is_small_int(o.data))
     {
-      return false;
+      return true;
     }
 
     auto const b{ dyn_cast<obj::boolean>(o) };
@@ -22,11 +22,6 @@ namespace jank::runtime
     }
 
     return true;
-  }
-
-  bool truthy(object_ref const o)
-  {
-    return truthy(o.data);
   }
 
   bool truthy(obj::nil_ref const)

--- a/compiler+runtime/src/cpp/jank/runtime/detail/native_array_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/detail/native_array_map.cpp
@@ -137,7 +137,7 @@ namespace jank::runtime::detail
 
   void native_array_map::insert_or_assign(object_ref const key, object_ref const val)
   {
-    if(key->type == runtime::object_type::keyword)
+    if(key.get_type() == runtime::object_type::keyword)
     {
       for(u8 i{}; i < length; i += 2)
       {
@@ -166,7 +166,7 @@ namespace jank::runtime::detail
 
   jtl::option<object_ref> native_array_map::find(object_ref const key) const
   {
-    if(key->type == runtime::object_type::keyword)
+    if(key.get_type() == runtime::object_type::keyword)
     {
       for(u8 i{}; i < length; i += 2)
       {
@@ -191,7 +191,7 @@ namespace jank::runtime::detail
 
   void native_array_map::erase(object_ref const key)
   {
-    if(key->type == runtime::object_type::keyword)
+    if(key.get_type() == runtime::object_type::keyword)
     {
       for(u8 i{}; i < length; i += 2)
       {

--- a/compiler+runtime/src/cpp/jank/runtime/ns.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/ns.cpp
@@ -177,7 +177,7 @@ namespace jank::runtime
     auto locked_vars(vars.wlock());
     if(auto const found = (*locked_vars)->data.find(sym))
     {
-      if(found->data->type == object_type::var)
+      if(found->get_type() == object_type::var)
       {
         auto const found_var(expect_object<runtime::var>(found->data));
         auto const clojure_core(__rt_ctx->find_ns(make_box<obj::symbol>("clojure.core")));
@@ -196,7 +196,7 @@ namespace jank::runtime
 
   jtl::result<void, error_ref> ns::refer_global(object_ref const sym)
   {
-    if(sym->type != object_type::symbol)
+    if(sym.get_type() != object_type::symbol)
     {
       return error::runtime_invalid_referred_global_symbol(object_source(sym));
     }
@@ -273,12 +273,12 @@ namespace jank::runtime
           auto const old_name{ first(p) };
           auto const new_name{ second(p) };
 
-          if(old_name->type != object_type::symbol
+          if(old_name.get_type() != object_type::symbol
              || !expect_object<obj::symbol>(old_name)->ns.empty())
           {
             return error::runtime_invalid_referred_global_symbol(object_source(old_name));
           }
-          if(new_name->type != object_type::symbol
+          if(new_name.get_type() != object_type::symbol
              || !expect_object<obj::symbol>(new_name)->ns.empty())
           {
             return error::runtime_invalid_referred_global_symbol(object_source(new_name));
@@ -298,10 +298,10 @@ namespace jank::runtime
               util::format(
                 "'{}' already refers to {} in namespace '{}'. A '{}' referred global will not be "
                 "accessible, since vars are resolved before C++ referred globals.",
-                new_name->to_code_string(),
+                new_name.to_code_string(),
                 existing_var->to_code_string(),
                 name->to_string(),
-                new_name->to_code_string()),
+                new_name.to_code_string()),
               object_source(new_name));
           }
 

--- a/compiler+runtime/src/cpp/jank/runtime/obj/array_chunk.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/array_chunk.cpp
@@ -1,6 +1,7 @@
 #include <jank/runtime/obj/array_chunk.hpp>
 #include <jank/runtime/obj/number.hpp>
 #include <jank/runtime/core/to_string.hpp>
+#include <jank/runtime/core/math.hpp>
 #include <jank/runtime/rtti.hpp>
 #include <jank/util/fmt.hpp>
 
@@ -58,9 +59,9 @@ namespace jank::runtime::obj
 
   object_ref array_chunk::nth(object_ref const index) const
   {
-    if(index.get_type() == object_type::integer)
+    if(is_integer(index))
     {
-      auto const i(expect_object<integer>(index)->data);
+      auto const i(to_i64(index));
       if(i < 0 || buffer.size() - offset <= static_cast<size_t>(i))
       {
         throw std::runtime_error{ util::format(
@@ -80,9 +81,9 @@ namespace jank::runtime::obj
 
   object_ref array_chunk::nth(object_ref const index, object_ref const fallback) const
   {
-    if(index.get_type() == object_type::integer)
+    if(is_integer(index))
     {
-      auto const i(expect_object<integer>(index)->data);
+      auto const i(to_i64(index));
       if(i < 0 || buffer.size() - offset <= static_cast<size_t>(i))
       {
         return fallback;

--- a/compiler+runtime/src/cpp/jank/runtime/obj/array_chunk.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/array_chunk.cpp
@@ -58,7 +58,7 @@ namespace jank::runtime::obj
 
   object_ref array_chunk::nth(object_ref const index) const
   {
-    if(index->type == object_type::integer)
+    if(index.get_type() == object_type::integer)
     {
       auto const i(expect_object<integer>(index)->data);
       if(i < 0 || buffer.size() - offset <= static_cast<size_t>(i))
@@ -80,7 +80,7 @@ namespace jank::runtime::obj
 
   object_ref array_chunk::nth(object_ref const index, object_ref const fallback) const
   {
-    if(index->type == object_type::integer)
+    if(index.get_type() == object_type::integer)
     {
       auto const i(expect_object<integer>(index)->data);
       if(i < 0 || buffer.size() - offset <= static_cast<size_t>(i))

--- a/compiler+runtime/src/cpp/jank/runtime/obj/big_integer.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/big_integer.cpp
@@ -121,6 +121,10 @@ namespace jank::runtime::obj
     {
       return data == expect_object<integer>(&o)->data;
     }
+    if(o.type == object_type::small_integer)
+    {
+      return data == expect_object<small_integer>(&o)->data;
+    }
     if(o.type == object_type::real)
     {
       try

--- a/compiler+runtime/src/cpp/jank/runtime/obj/deferred_cpp_function.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/deferred_cpp_function.cpp
@@ -31,11 +31,11 @@ namespace jank::runtime::obj
 
   void deferred_cpp_function::to_string(jtl::string_builder &buff) const
   {
-    auto const name(meta->get(__rt_ctx->intern_keyword("name").expect_ok()));
+    auto const name(meta.get(__rt_ctx->intern_keyword("name").expect_ok()));
     util::format_to(
       buff,
       "#object [{} {} {}]",
-      (name->type == object_type::nil ? "unknown" : try_object<persistent_string>(name)->data),
+      (name.get_type() == object_type::nil ? "unknown" : try_object<persistent_string>(name)->data),
       object_type_str(type),
       this);
   }
@@ -54,7 +54,7 @@ namespace jank::runtime::obj
     // auto const name(meta->get(__rt_ctx->intern_keyword("name").expect_ok()));
     //util::println(
     //  "lazily creating {}",
-    //  (name->type == object_type::nil ? "unknown" : try_object<persistent_string>(name)->data));
+    //  (name.get_type() == object_type::nil ? "unknown" : try_object<persistent_string>(name)->data));
 
     /* On the first invocation, we don't have a compiled_fn. We compile our C++ code, get a fn,
      * rebind the root of the var, and then apply our args to the new fn.*/

--- a/compiler+runtime/src/cpp/jank/runtime/obj/detail/base_persistent_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/detail/base_persistent_map.cpp
@@ -172,7 +172,7 @@ namespace jank::runtime::obj::detail
       return merge(ret, head);
     }
 
-    if(head->type != object_type::persistent_vector)
+    if(head.get_type() != object_type::persistent_vector)
     {
       throw std::runtime_error{ util::format("invalid map entry: {}",
                                              runtime::to_code_string(head)) };

--- a/compiler+runtime/src/cpp/jank/runtime/obj/integer_range.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/integer_range.cpp
@@ -7,12 +7,12 @@
 
 namespace jank::runtime::obj
 {
-  static bool positive_step_bounds_check(integer_ref const val, integer_ref const end)
+  static bool positive_step_bounds_check(object_ref const val, object_ref const end)
   {
     return lte(end, val);
   }
 
-  static bool negative_step_bounds_check(integer_ref const val, integer_ref const end)
+  static bool negative_step_bounds_check(object_ref const val, object_ref const end)
   {
     return lte(val, end);
   }
@@ -22,7 +22,7 @@ namespace jank::runtime::obj
   {
   }
 
-  integer_range::integer_range(integer_ref const end)
+  integer_range::integer_range(object_ref const end)
     : object{ obj_type, obj_behaviors }
     , start{ make_box<integer>(0) }
     , end{ end }
@@ -31,7 +31,7 @@ namespace jank::runtime::obj
   {
   }
 
-  integer_range::integer_range(integer_ref const start, integer_ref const end)
+  integer_range::integer_range(object_ref const start, object_ref const end)
     : object{ obj_type, obj_behaviors }
     , start{ start }
     , end{ end }
@@ -40,9 +40,7 @@ namespace jank::runtime::obj
   {
   }
 
-  integer_range::integer_range(integer_ref const start,
-                               integer_ref const end,
-                               integer_ref const step)
+  integer_range::integer_range(object_ref const start, object_ref const end, object_ref const step)
     : object{ obj_type, obj_behaviors }
     , start{ start }
     , end{ end }
@@ -53,9 +51,9 @@ namespace jank::runtime::obj
   {
   }
 
-  integer_range::integer_range(integer_ref const start,
-                               integer_ref const end,
-                               integer_ref const step,
+  integer_range::integer_range(object_ref const start,
+                               object_ref const end,
+                               object_ref const step,
                                integer_range::bounds_check_t const bounds_check)
     : object{ obj_type, obj_behaviors }
     , start{ start }
@@ -65,7 +63,7 @@ namespace jank::runtime::obj
   {
   }
 
-  object_ref integer_range::create(integer_ref const end)
+  object_ref integer_range::create(object_ref const end)
   {
     if(is_pos(end))
     {
@@ -77,13 +75,13 @@ namespace jank::runtime::obj
     return persistent_list::empty();
   }
 
-  object_ref integer_range::create(integer_ref const start, integer_ref const end)
+  object_ref integer_range::create(object_ref const start, object_ref const end)
   {
     return create(start, end, make_box<integer>(1));
   }
 
   object_ref
-  integer_range::create(integer_ref const start, integer_ref const end, integer_ref const step)
+  integer_range::create(object_ref const start, object_ref const end, object_ref const step)
   {
     if((is_pos(step) && lt(end, start)) || (is_neg(step) && lt(start, end)) || is_equiv(start, end))
     {
@@ -111,7 +109,7 @@ namespace jank::runtime::obj
     return make_box<integer_range>(start, end, step, bounds_check);
   }
 
-  integer_ref integer_range::first() const
+  object_ref integer_range::first() const
   {
     return start;
   }
@@ -122,7 +120,7 @@ namespace jank::runtime::obj
     {
       return {};
     }
-    return make_box<integer_range>(make_box<integer>(add(start, step)), end, step, bounds_check);
+    return make_box<integer_range>(add(start, step), end, step, bounds_check);
   }
 
   integer_range_ref integer_range::next_in_place()
@@ -131,7 +129,7 @@ namespace jank::runtime::obj
     {
       return {};
     }
-    start = make_box<integer>(add(start, step));
+    start = add(start, step);
     return this;
   }
 
@@ -180,19 +178,19 @@ namespace jank::runtime::obj
 
   usize integer_range::count() const
   {
-    auto const s{ step->data };
+    auto const s{ runtime::to_i64(step) };
     if(s == 0)
     {
-      throw std::runtime_error("[Integer-Range] Step shouldn't be 0");
+      throw std::runtime_error("integer_range step shouldn't be 0.");
     }
 
-    auto const diff{ sub(end, start) };
+    auto const diff{ runtime::to_i64(sub(end, start)) };
     auto const offset{ s > 0 ? -1 : 1 };
 
     if((s > 0 && diff > std::numeric_limits<i64>::max() - s + offset)
        || (s < 0 && diff < std::numeric_limits<i64>::min() - s + offset))
     {
-      throw std::runtime_error("[Integer-Range] Overflow occurred in arithmetic");
+      throw std::runtime_error("integer_range overflow occurred in arithmetic.");
     }
 
     return static_cast<size_t>((diff + offset + s) / s);

--- a/compiler+runtime/src/cpp/jank/runtime/obj/integer_range.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/integer_range.cpp
@@ -24,9 +24,7 @@ namespace jank::runtime::obj
 
   integer_range::integer_range(i64 const end)
     : object{ obj_type, obj_behaviors }
-    , start{ 0 }
     , end{ end }
-    , step{ 1 }
     , bounds_check{ static_cast<bounds_check_t>(positive_step_bounds_check) }
   {
   }
@@ -35,7 +33,6 @@ namespace jank::runtime::obj
     : object{ obj_type, obj_behaviors }
     , start{ start }
     , end{ end }
-    , step{ 1 }
     , bounds_check{ static_cast<bounds_check_t>(positive_step_bounds_check) }
   {
   }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/integer_range.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/integer_range.cpp
@@ -7,14 +7,14 @@
 
 namespace jank::runtime::obj
 {
-  static bool positive_step_bounds_check(object_ref const val, object_ref const end)
+  static bool positive_step_bounds_check(i64 const val, i64 const end)
   {
-    return lte(end, val);
+    return end <= val;
   }
 
-  static bool negative_step_bounds_check(object_ref const val, object_ref const end)
+  static bool negative_step_bounds_check(i64 const val, i64 const end)
   {
-    return lte(val, end);
+    return val <= end;
   }
 
   integer_range::integer_range()
@@ -22,38 +22,37 @@ namespace jank::runtime::obj
   {
   }
 
-  integer_range::integer_range(object_ref const end)
+  integer_range::integer_range(i64 const end)
     : object{ obj_type, obj_behaviors }
-    , start{ make_box<integer>(0) }
+    , start{ 0 }
     , end{ end }
-    , step{ make_box<integer>(1) }
+    , step{ 1 }
     , bounds_check{ static_cast<bounds_check_t>(positive_step_bounds_check) }
   {
   }
 
-  integer_range::integer_range(object_ref const start, object_ref const end)
+  integer_range::integer_range(i64 const start, i64 const end)
     : object{ obj_type, obj_behaviors }
     , start{ start }
     , end{ end }
-    , step{ make_box<integer>(1) }
+    , step{ 1 }
     , bounds_check{ static_cast<bounds_check_t>(positive_step_bounds_check) }
   {
   }
 
-  integer_range::integer_range(object_ref const start, object_ref const end, object_ref const step)
+  integer_range::integer_range(i64 const start, i64 const end, i64 const step)
     : object{ obj_type, obj_behaviors }
     , start{ start }
     , end{ end }
     , step{ step }
-    , bounds_check{ lt(static_cast<i64>(0), step.erase())
-                      ? static_cast<bounds_check_t>(positive_step_bounds_check)
-                      : static_cast<bounds_check_t>(negative_step_bounds_check) }
+    , bounds_check{ 0 < step ? static_cast<bounds_check_t>(positive_step_bounds_check)
+                             : static_cast<bounds_check_t>(negative_step_bounds_check) }
   {
   }
 
-  integer_range::integer_range(object_ref const start,
-                               object_ref const end,
-                               object_ref const step,
+  integer_range::integer_range(i64 const start,
+                               i64 const end,
+                               i64 const step,
                                integer_range::bounds_check_t const bounds_check)
     : object{ obj_type, obj_behaviors }
     , start{ start }
@@ -63,38 +62,38 @@ namespace jank::runtime::obj
   {
   }
 
-  object_ref integer_range::create(object_ref const end)
+  object_ref integer_range::create(i64 const end)
   {
-    if(is_pos(end))
+    if(0 < end)
     {
-      return make_box<integer_range>(make_box<integer>(0),
+      return make_box<integer_range>(0,
                                      end,
-                                     make_box<integer>(1),
+                                     1,
                                      static_cast<bounds_check_t>(positive_step_bounds_check));
     }
     return persistent_list::empty();
   }
 
-  object_ref integer_range::create(object_ref const start, object_ref const end)
+  object_ref integer_range::create(i64 const start, i64 const end)
   {
-    return create(start, end, make_box<integer>(1));
+    return create(start, end, 1);
   }
 
-  object_ref
-  integer_range::create(object_ref const start, object_ref const end, object_ref const step)
+  object_ref integer_range::create(i64 const start, i64 const end, i64 const step)
   {
-    if((is_pos(step) && lt(end, start)) || (is_neg(step) && lt(start, end)) || is_equiv(start, end))
+    if(((0 < step) && (end < start)) || ((step < 0) && (start < end)) || (start == end))
     {
       return persistent_list::empty();
     }
-    else if(is_zero(step))
+
+    else if(step == 0)
     {
-      return repeat::create(start);
+      return repeat::create(make_box(start));
     }
     return make_box<integer_range>(start,
                                    end,
                                    step,
-                                   is_pos(step)
+                                   0 < step
                                      ? static_cast<bounds_check_t>(positive_step_bounds_check)
                                      : static_cast<bounds_check_t>(negative_step_bounds_check));
   }
@@ -111,7 +110,7 @@ namespace jank::runtime::obj
 
   object_ref integer_range::first() const
   {
-    return start;
+    return make_box(start);
   }
 
   integer_range_ref integer_range::next() const
@@ -120,7 +119,7 @@ namespace jank::runtime::obj
     {
       return {};
     }
-    return make_box<integer_range>(add(start, step), end, step, bounds_check);
+    return make_box<integer_range>(start + step, end, step, bounds_check);
   }
 
   integer_range_ref integer_range::next_in_place()
@@ -129,7 +128,7 @@ namespace jank::runtime::obj
     {
       return {};
     }
-    start = add(start, step);
+    start += step;
     return this;
   }
 
@@ -178,13 +177,13 @@ namespace jank::runtime::obj
 
   usize integer_range::count() const
   {
-    auto const s{ runtime::to_i64(step) };
+    auto const s{ step };
     if(s == 0)
     {
       throw std::runtime_error("integer_range step shouldn't be 0.");
     }
 
-    auto const diff{ runtime::to_i64(sub(end, start)) };
+    auto const diff{ end - start };
     auto const offset{ s > 0 ? -1 : 1 };
 
     if((s > 0 && diff > std::numeric_limits<i64>::max() - s + offset)

--- a/compiler+runtime/src/cpp/jank/runtime/obj/jit_closure.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/jit_closure.cpp
@@ -31,11 +31,11 @@ namespace jank::runtime::obj
 
   void jit_closure::to_string(jtl::string_builder &buff) const
   {
-    auto const name(meta->get(__rt_ctx->intern_keyword("name").expect_ok()));
+    auto const name(meta.get(__rt_ctx->intern_keyword("name").expect_ok()));
     util::format_to(
       buff,
       "#object [{} {} {}]",
-      (name->type == object_type::nil ? "unknown" : try_object<persistent_string>(name)->data),
+      (name.get_type() == object_type::nil ? "unknown" : try_object<persistent_string>(name)->data),
       object_type_str(type),
       this);
   }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/jit_function.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/jit_function.cpp
@@ -30,11 +30,11 @@ namespace jank::runtime::obj
 
   void jit_function::to_string(jtl::string_builder &buff) const
   {
-    auto const name(meta->get(__rt_ctx->intern_keyword("name").expect_ok()));
+    auto const name(meta.get(__rt_ctx->intern_keyword("name").expect_ok()));
     util::format_to(
       buff,
       "#object [{} {} {}]",
-      (name->type == object_type::nil ? "unknown" : try_object<persistent_string>(name)->data),
+      (name.get_type() == object_type::nil ? "unknown" : try_object<persistent_string>(name)->data),
       object_type_str(type),
       this);
   }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/lazy_sequence.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/lazy_sequence.cpp
@@ -118,7 +118,7 @@ namespace jank::runtime::obj
     {
       auto ls{ sv };
       sv = jank_nil;
-      if(ls.is_some() && ls->type == object_type::lazy_sequence)
+      if(ls.is_some() && ls.get_type() == object_type::lazy_sequence)
       {
         ls = unwrap(ls);
       }
@@ -153,7 +153,7 @@ namespace jank::runtime::obj
 
   object_ref lazy_sequence::unwrap(object_ref ls) const
   {
-    while(ls.is_some() && ls->type == object_type::lazy_sequence)
+    while(ls.is_some() && ls.get_type() == object_type::lazy_sequence)
     {
       ls = expect_object<lazy_sequence>(ls)->sval();
     }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/native_function_wrapper.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/native_function_wrapper.cpp
@@ -29,7 +29,7 @@ namespace jank::runtime::obj
 
   void native_function_wrapper::to_string(jtl::string_builder &buff) const
   {
-    auto const name(meta->get(__rt_ctx->intern_keyword("name").expect_ok()));
+    auto const name(meta.get(__rt_ctx->intern_keyword("name").expect_ok()));
     util::format_to(buff,
                     "#object [{} {} {}]",
                     (name.is_nil() ? "unknown" : try_object<persistent_string>(name)->data),

--- a/compiler+runtime/src/cpp/jank/runtime/obj/nil.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/nil.cpp
@@ -1,3 +1,4 @@
+#include <jank/runtime/oref.hpp>
 #include <jank/runtime/obj/nil.hpp>
 #include <jank/runtime/obj/persistent_array_map.hpp>
 #include <jank/runtime/obj/cons.hpp>

--- a/compiler+runtime/src/cpp/jank/runtime/obj/number.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/number.cpp
@@ -1,5 +1,6 @@
 #include <cmath>
 
+#include <jank/runtime/oref.hpp>
 #include <jank/runtime/obj/number.hpp>
 #include <jank/runtime/visit.hpp>
 #include <jank/util/fmt.hpp>
@@ -86,6 +87,12 @@ namespace jank::runtime::obj
       return data == i->data;
     }
 
+    if(o.type == object_type::small_integer)
+    {
+      auto const i(expect_object<small_integer>(&o));
+      return data == i->data;
+    }
+
     if(o.type != object_type::integer)
     {
       return false;
@@ -137,6 +144,87 @@ namespace jank::runtime::obj
   }
 
   f64 integer::to_real() const
+  {
+    return static_cast<f64>(data);
+  }
+
+  /***** small_integer *****/
+  small_integer::small_integer()
+    : object{ obj_type, obj_behaviors }
+  {
+  }
+
+  small_integer::small_integer(i64 const d)
+    : object{ obj_type, obj_behaviors }
+    , data{ d }
+  {
+  }
+
+  bool small_integer::equal(object const &o) const
+  {
+    if(o.type == object_type::big_integer)
+    {
+      auto const i(expect_object<big_integer>(&o));
+      return data == i->data;
+    }
+
+    if(o.type == object_type::integer)
+    {
+      auto const i(expect_object<integer>(&o));
+      return data == i->data;
+    }
+
+    if(o.type != object_type::small_integer)
+    {
+      return false;
+    }
+
+    auto const i(expect_object<small_integer>(&o));
+    return data == i->data;
+  }
+
+  jtl::immutable_string small_integer::to_string() const
+  {
+    jtl::string_builder sb;
+    return sb(data).release();
+  }
+
+  void small_integer::to_string(jtl::string_builder &buff) const
+  {
+    buff(data);
+  }
+
+  jtl::immutable_string small_integer::to_code_string() const
+  {
+    return to_string();
+  }
+
+  uhash small_integer::to_hash() const
+  {
+    return hash::integer(data);
+  }
+
+  i64 small_integer::compare(object const &o) const
+  {
+    return visit_number_like(
+      [this](auto const typed_o) -> i64 { return (typed_o->data < data) - (data < typed_o->data); },
+      [&]() -> i64 {
+        throw std::runtime_error{ util::format("not comparable: {}", runtime::to_string(&o)) };
+      },
+      &o);
+  }
+
+  i64 small_integer::compare(small_integer const &o) const
+  {
+    return (o.data < data) - (data < o.data);
+  }
+
+  i64 small_integer::to_integer() const
+  {
+    return data;
+  }
+
+  f64 small_integer::to_real() const
   {
     return static_cast<f64>(data);
   }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_string.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_string.cpp
@@ -3,6 +3,7 @@
 #include <jank/runtime/rtti.hpp>
 #include <jank/runtime/core/make_box.hpp>
 #include <jank/runtime/core/to_string.hpp>
+#include <jank/runtime/core/math.hpp>
 #include <jank/util/escape.hpp>
 #include <jank/util/fmt.hpp>
 
@@ -74,9 +75,9 @@ namespace jank::runtime::obj
 
   object_ref persistent_string::get(object_ref const key, object_ref const fallback) const
   {
-    if(key.get_type() == object_type::integer)
+    if(is_integer(key))
     {
-      auto const i(expect_object<integer>(key)->data);
+      auto const i(to_i64(key));
       if(i < 0 || data.size() <= static_cast<size_t>(i))
       {
         return fallback;
@@ -91,9 +92,9 @@ namespace jank::runtime::obj
 
   bool persistent_string::contains(object_ref const key) const
   {
-    if(key.get_type() == object_type::integer)
+    if(is_integer(key))
     {
-      auto const i(expect_object<integer>(key)->data);
+      auto const i(to_i64(key));
       return 0 <= i && static_cast<size_t>(i) < data.size();
     }
     return false;
@@ -101,9 +102,9 @@ namespace jank::runtime::obj
 
   object_ref persistent_string::nth(object_ref const index) const
   {
-    if(index.get_type() == object_type::integer)
+    if(is_integer(index))
     {
-      auto const i(expect_object<integer>(index)->data);
+      auto const i(to_i64(index));
       if(i < 0 || data.size() <= static_cast<size_t>(i))
       {
         throw std::runtime_error{

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_string.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_string.cpp
@@ -74,7 +74,7 @@ namespace jank::runtime::obj
 
   object_ref persistent_string::get(object_ref const key, object_ref const fallback) const
   {
-    if(key->type == object_type::integer)
+    if(key.get_type() == object_type::integer)
     {
       auto const i(expect_object<integer>(key)->data);
       if(i < 0 || data.size() <= static_cast<size_t>(i))
@@ -91,7 +91,7 @@ namespace jank::runtime::obj
 
   bool persistent_string::contains(object_ref const key) const
   {
-    if(key->type == object_type::integer)
+    if(key.get_type() == object_type::integer)
     {
       auto const i(expect_object<integer>(key)->data);
       return 0 <= i && static_cast<size_t>(i) < data.size();
@@ -101,7 +101,7 @@ namespace jank::runtime::obj
 
   object_ref persistent_string::nth(object_ref const index) const
   {
-    if(index->type == object_type::integer)
+    if(index.get_type() == object_type::integer)
     {
       auto const i(expect_object<integer>(index)->data);
       if(i < 0 || data.size() <= static_cast<size_t>(i))

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_vector.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_vector.cpp
@@ -4,6 +4,7 @@
 #include <jank/runtime/core/equal.hpp>
 #include <jank/runtime/core/seq.hpp>
 #include <jank/runtime/core/seq_ext.hpp>
+#include <jank/runtime/core/math.hpp>
 #include <jank/runtime/behavior/sequential.hpp>
 #include <jank/util/fmt.hpp>
 
@@ -209,9 +210,9 @@ namespace jank::runtime::obj
 
   object_ref persistent_vector::get(object_ref const key, object_ref const fallback) const
   {
-    if(key.get_type() == object_type::integer)
+    if(is_integer(key))
     {
-      auto const i(expect_object<integer>(key)->data);
+      auto const i(to_i64(key));
       if(i < 0 || data.size() <= static_cast<size_t>(i))
       {
         return fallback;
@@ -226,9 +227,9 @@ namespace jank::runtime::obj
 
   object_ref persistent_vector::find(object_ref const key) const
   {
-    if(key.get_type() == object_type::integer)
+    if(is_integer(key))
     {
-      auto const i(expect_object<integer>(key)->data);
+      auto const i(to_i64(key));
       if(i < 0 || data.size() <= static_cast<size_t>(i))
       {
         return {};
@@ -244,9 +245,9 @@ namespace jank::runtime::obj
 
   bool persistent_vector::contains(object_ref const key) const
   {
-    if(key.get_type() == object_type::integer)
+    if(is_integer(key))
     {
-      auto const i(expect_object<integer>(key)->data);
+      auto const i(to_i64(key));
       return i >= 0 && static_cast<size_t>(i) < data.size();
     }
     else
@@ -257,12 +258,12 @@ namespace jank::runtime::obj
 
   persistent_vector_ref persistent_vector::assoc(object_ref const key, object_ref const val) const
   {
-    if(key.get_type() != object_type::integer)
+    if(!is_integer(key))
     {
       throw std::runtime_error{ "Key must be integer." };
     }
 
-    auto const i(expect_object<integer>(key)->data);
+    auto const i(to_i64(key));
     auto const size(static_cast<i64>(data.size()));
 
     if(i > size || 0 > i)
@@ -307,9 +308,9 @@ namespace jank::runtime::obj
 
   object_ref persistent_vector::nth(object_ref const index) const
   {
-    if(index.get_type() == object_type::integer)
+    if(is_integer(index))
     {
-      auto const i(expect_object<integer>(index)->data);
+      auto const i(to_i64(index));
       if(i < 0 || data.size() <= static_cast<size_t>(i))
       {
         throw std::runtime_error{

--- a/compiler+runtime/src/cpp/jank/runtime/obj/persistent_vector.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/persistent_vector.cpp
@@ -209,7 +209,7 @@ namespace jank::runtime::obj
 
   object_ref persistent_vector::get(object_ref const key, object_ref const fallback) const
   {
-    if(key->type == object_type::integer)
+    if(key.get_type() == object_type::integer)
     {
       auto const i(expect_object<integer>(key)->data);
       if(i < 0 || data.size() <= static_cast<size_t>(i))
@@ -226,7 +226,7 @@ namespace jank::runtime::obj
 
   object_ref persistent_vector::find(object_ref const key) const
   {
-    if(key->type == object_type::integer)
+    if(key.get_type() == object_type::integer)
     {
       auto const i(expect_object<integer>(key)->data);
       if(i < 0 || data.size() <= static_cast<size_t>(i))
@@ -244,7 +244,7 @@ namespace jank::runtime::obj
 
   bool persistent_vector::contains(object_ref const key) const
   {
-    if(key->type == object_type::integer)
+    if(key.get_type() == object_type::integer)
     {
       auto const i(expect_object<integer>(key)->data);
       return i >= 0 && static_cast<size_t>(i) < data.size();
@@ -257,7 +257,7 @@ namespace jank::runtime::obj
 
   persistent_vector_ref persistent_vector::assoc(object_ref const key, object_ref const val) const
   {
-    if(key->type != object_type::integer)
+    if(key.get_type() != object_type::integer)
     {
       throw std::runtime_error{ "Key must be integer." };
     }
@@ -307,7 +307,7 @@ namespace jank::runtime::obj
 
   object_ref persistent_vector::nth(object_ref const index) const
   {
-    if(index->type == object_type::integer)
+    if(index.get_type() == object_type::integer)
     {
       auto const i(expect_object<integer>(index)->data);
       if(i < 0 || data.size() <= static_cast<size_t>(i))

--- a/compiler+runtime/src/cpp/jank/runtime/obj/ratio.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/ratio.cpp
@@ -23,18 +23,18 @@ namespace jank::runtime::obj
   static native_big_integer extract_big_integer(object_ref const d)
   {
     native_big_integer result{};
-    if(d->type == object_type::big_integer)
+    if(d.get_type() == object_type::big_integer)
     {
       result = expect_object<big_integer>(d)->data;
     }
-    else if(d->type == object_type::integer)
+    else if(d.get_type() == object_type::integer)
     {
       result = expect_object<integer>(d)->data;
     }
     else
     {
       throw std::runtime_error{
-        util::format("Type {} cannot be used as a ratio numerator or denominator.", d->type)
+        util::format("Type {} cannot be used as a ratio numerator or denominator.", d.get_type())
       };
     }
     return result;
@@ -181,12 +181,12 @@ namespace jank::runtime::obj
     return ratio::create(num, denom);
   }
 
-  ratio_ref operator+(integer_ref const l, ratio_data const &r)
+  ratio_data operator+(integer_ref const l, ratio_data const &r)
   {
     return l->data + r;
   }
 
-  ratio_ref operator+(ratio_data const &l, integer_ref const r)
+  ratio_data operator+(ratio_data const &l, integer_ref const r)
   {
     return r + l;
   }
@@ -208,12 +208,12 @@ namespace jank::runtime::obj
     return ratio::create(num, denom);
   }
 
-  ratio_ref operator-(integer_ref const l, ratio_data const &r)
+  ratio_data operator-(integer_ref const l, ratio_data const &r)
   {
     return l->data - r;
   }
 
-  ratio_ref operator-(ratio_data const &l, integer_ref const r)
+  ratio_data operator-(ratio_data const &l, integer_ref const r)
   {
     return l - r->data;
   }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/ratio.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/ratio.cpp
@@ -31,6 +31,10 @@ namespace jank::runtime::obj
     {
       result = expect_object<integer>(d)->data;
     }
+    else if(d.get_type() == object_type::small_integer)
+    {
+      result = expect_object<small_integer>(d)->data;
+    }
     else
     {
       throw std::runtime_error{

--- a/compiler+runtime/src/cpp/jank/runtime/obj/tagged_literal.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/tagged_literal.cpp
@@ -54,7 +54,7 @@ namespace jank::runtime::obj
 
   uhash tagged_literal::to_hash() const
   {
-    return hash::combine(hash::visit(tag.get()), hash::visit(form.get()));
+    return hash::combine(hash::visit(tag), hash::visit(form));
   }
 
   object_ref tagged_literal::get(object_ref const key, object_ref const fallback) const

--- a/compiler+runtime/src/cpp/jank/runtime/obj/transient_array_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/transient_array_map.cpp
@@ -110,7 +110,7 @@ namespace jank::runtime::obj
       return runtime::merge_in_place(this, head);
     }
 
-    if(head->type != object_type::persistent_vector)
+    if(head.get_type() != object_type::persistent_vector)
     {
       throw std::runtime_error{ util::format("invalid map entry: {}", runtime::to_string(head)) };
     }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/transient_hash_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/transient_hash_map.cpp
@@ -121,7 +121,7 @@ namespace jank::runtime::obj
       return expect_object<transient_hash_map>(runtime::merge_in_place(this, head));
     }
 
-    if(head->type != object_type::persistent_vector)
+    if(head.get_type() != object_type::persistent_vector)
     {
       throw std::runtime_error{ util::format("invalid map entry: {}", runtime::to_string(head)) };
     }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/transient_sorted_map.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/transient_sorted_map.cpp
@@ -105,7 +105,7 @@ namespace jank::runtime::obj
       return expect_object<transient_sorted_map>(runtime::merge_in_place(this, head));
     }
 
-    if(head->type != object_type::persistent_vector)
+    if(head.get_type() != object_type::persistent_vector)
     {
       throw std::runtime_error{ util::format("invalid map entry: {}", runtime::to_string(head)) };
     }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/transient_vector.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/transient_vector.cpp
@@ -3,6 +3,7 @@
 #include <jank/runtime/obj/nil.hpp>
 #include <jank/runtime/obj/number.hpp>
 #include <jank/runtime/core/to_string.hpp>
+#include <jank/runtime/core/math.hpp>
 #include <jank/runtime/rtti.hpp>
 #include <jank/util/fmt.hpp>
 
@@ -52,12 +53,12 @@ namespace jank::runtime::obj
   transient_vector_ref transient_vector::assoc_in_place(object_ref const key, object_ref const val)
   {
     assert_active();
-    if(key.get_type() != object_type::integer)
+    if(!is_integer(key))
     {
       throw std::runtime_error{ "Key must be an integer." };
     }
 
-    auto const i(expect_object<integer>(key)->data);
+    auto const i(to_i64(key));
     auto const size(static_cast<i64>(data.size()));
 
     if(i > size || 0 > i)
@@ -91,9 +92,9 @@ namespace jank::runtime::obj
   object_ref transient_vector::call(object_ref const idx) const
   {
     assert_active();
-    if(idx.get_type() == object_type::integer)
+    if(is_integer(idx))
     {
-      auto const i(expect_object<integer>(idx)->data);
+      auto const i(to_i64(idx));
       if(i < 0 || data.size() <= static_cast<size_t>(i))
       {
         throw std::runtime_error{
@@ -113,9 +114,9 @@ namespace jank::runtime::obj
   object_ref transient_vector::get(object_ref const idx) const
   {
     assert_active();
-    if(idx.get_type() == object_type::integer)
+    if(is_integer(idx))
     {
-      auto const i(expect_object<integer>(idx)->data);
+      auto const i(to_i64(idx));
       if(i < 0 || data.size() <= static_cast<size_t>(i))
       {
         return {};
@@ -133,9 +134,9 @@ namespace jank::runtime::obj
   object_ref transient_vector::get(object_ref const idx, object_ref const fallback) const
   {
     assert_active();
-    if(idx.get_type() == object_type::integer)
+    if(is_integer(idx))
     {
-      auto const i(expect_object<integer>(idx)->data);
+      auto const i(to_i64(idx));
       if(i < 0 || data.size() <= static_cast<size_t>(i))
       {
         return fallback;
@@ -152,9 +153,9 @@ namespace jank::runtime::obj
 
   object_ref transient_vector::find(object_ref const idx) const
   {
-    if(idx.get_type() == object_type::integer)
+    if(is_integer(idx))
     {
-      auto const i(expect_object<integer>(idx)->data);
+      auto const i(to_i64(idx));
       if(i < 0 || data.size() <= static_cast<size_t>(i))
       {
         return {};
@@ -171,9 +172,9 @@ namespace jank::runtime::obj
 
   bool transient_vector::contains(object_ref const elem) const
   {
-    if(elem.get_type() == object_type::integer)
+    if(is_integer(elem))
     {
-      auto const i(expect_object<integer>(elem)->data);
+      auto const i(to_i64(elem));
       return i >= 0 && static_cast<size_t>(i) < data.size();
     }
     else

--- a/compiler+runtime/src/cpp/jank/runtime/obj/transient_vector.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/transient_vector.cpp
@@ -52,7 +52,7 @@ namespace jank::runtime::obj
   transient_vector_ref transient_vector::assoc_in_place(object_ref const key, object_ref const val)
   {
     assert_active();
-    if(key->type != object_type::integer)
+    if(key.get_type() != object_type::integer)
     {
       throw std::runtime_error{ "Key must be an integer." };
     }
@@ -91,7 +91,7 @@ namespace jank::runtime::obj
   object_ref transient_vector::call(object_ref const idx) const
   {
     assert_active();
-    if(idx->type == object_type::integer)
+    if(idx.get_type() == object_type::integer)
     {
       auto const i(expect_object<integer>(idx)->data);
       if(i < 0 || data.size() <= static_cast<size_t>(i))
@@ -113,7 +113,7 @@ namespace jank::runtime::obj
   object_ref transient_vector::get(object_ref const idx) const
   {
     assert_active();
-    if(idx->type == object_type::integer)
+    if(idx.get_type() == object_type::integer)
     {
       auto const i(expect_object<integer>(idx)->data);
       if(i < 0 || data.size() <= static_cast<size_t>(i))
@@ -133,7 +133,7 @@ namespace jank::runtime::obj
   object_ref transient_vector::get(object_ref const idx, object_ref const fallback) const
   {
     assert_active();
-    if(idx->type == object_type::integer)
+    if(idx.get_type() == object_type::integer)
     {
       auto const i(expect_object<integer>(idx)->data);
       if(i < 0 || data.size() <= static_cast<size_t>(i))
@@ -152,7 +152,7 @@ namespace jank::runtime::obj
 
   object_ref transient_vector::find(object_ref const idx) const
   {
-    if(idx->type == object_type::integer)
+    if(idx.get_type() == object_type::integer)
     {
       auto const i(expect_object<integer>(idx)->data);
       if(i < 0 || data.size() <= static_cast<size_t>(i))
@@ -171,7 +171,7 @@ namespace jank::runtime::obj
 
   bool transient_vector::contains(object_ref const elem) const
   {
-    if(elem->type == object_type::integer)
+    if(elem.get_type() == object_type::integer)
     {
       auto const i(expect_object<integer>(elem)->data);
       return i >= 0 && static_cast<size_t>(i) < data.size();

--- a/compiler+runtime/src/cpp/jank/runtime/object.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/object.cpp
@@ -197,9 +197,14 @@ namespace jank::runtime
     return {};
   }
 
+  i64 object::compare(object const &) const
+  {
+    throw error::runtime_unsupported_behavior(type, "compare", object_source(this));
+  }
+
   bool very_equal_to::operator()(object_ref const lhs, object_ref const rhs) const noexcept
   {
-    if(lhs->type != rhs->type)
+    if(lhs.get_type() != rhs.get_type())
     {
       return false;
     }
@@ -209,7 +214,7 @@ namespace jank::runtime
   bool
   very_equal_to_with_meta::operator()(object_ref const lhs, object_ref const rhs) const noexcept
   {
-    if(lhs->type != rhs->type)
+    if(lhs.get_type() != rhs.get_type())
     {
       return false;
     }

--- a/compiler+runtime/src/cpp/jank/runtime/perf.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/perf.cpp
@@ -28,7 +28,7 @@ namespace jank::runtime::perf
     //config.mWarmup = 1000;
 
     ankerl::nanobench::Bench().config(config).run(static_cast<std::string>(label_str), [&] {
-      auto const res(f->call());
+      auto const res(f.call());
       ankerl::nanobench::doNotOptimizeAway(res);
     });
     return {};

--- a/compiler+runtime/src/cpp/jank/runtime/rtti.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/rtti.cpp
@@ -1,0 +1,14 @@
+#include <jank/runtime/rtti.hpp>
+
+namespace jank::runtime
+{
+  template <>
+  [[gnu::always_inline, gnu::flatten, gnu::hot]]
+  obj::small_integer_ref expect_object<obj::small_integer>(object const * const o)
+  {
+    jank_debug_assert(o);
+    jank_debug_assert(o->type == object_type::small_integer);
+
+    return static_cast<obj::small_integer *>(const_cast<object *>(o))->data;
+  }
+}

--- a/compiler+runtime/src/cpp/jank/runtime/var.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/var.cpp
@@ -87,7 +87,7 @@ namespace jank::runtime
 
   bool var::is_bound() const
   {
-    return deref()->type != object_type::var_unbound_root;
+    return deref().get_type() != object_type::var_unbound_root;
   }
 
   object_ref var::get_root() const
@@ -233,7 +233,7 @@ namespace jank::runtime
 
   uhash var_thread_binding::to_hash() const
   {
-    return hash::visit(value.get());
+    return hash::visit(value);
   }
 
   var_unbound_root::var_unbound_root(var_ref const var)

--- a/compiler+runtime/src/cpp/jank/util/try.cpp
+++ b/compiler+runtime/src/cpp/jank/util/try.cpp
@@ -90,7 +90,7 @@ namespace jank::util
 
   void print_exception(runtime::object_ref const e)
   {
-    if(e->type == runtime::object_type::persistent_string)
+    if(e.get_type() == runtime::object_type::persistent_string)
     {
       util::println("Uncaught exception: {}\n", runtime::to_string(e));
     }

--- a/compiler+runtime/src/cpp/jtl/string_builder.cpp
+++ b/compiler+runtime/src/cpp/jtl/string_builder.cpp
@@ -7,6 +7,8 @@
 #include <jtl/string_builder.hpp>
 #include <jtl/format/style.hpp>
 
+#include <jank/runtime/obj/ratio.hpp>
+
 namespace jtl
 {
   using allocator_type = jank::native_allocator<string_builder::value_type>;
@@ -238,6 +240,13 @@ namespace jtl
   string_builder &string_builder::operator()(jank::native_big_integer const &d) &
   {
     return (*this)(d.str());
+  }
+
+  string_builder &string_builder::operator()(jank::runtime::obj::ratio_data const &r) &
+  {
+    (*this)(r.numerator);
+    (*this)('/');
+    return (*this)(r.denominator);
   }
 
   string_builder &string_builder::operator()(char const d) &

--- a/compiler+runtime/src/jank/clojure/core.jank
+++ b/compiler+runtime/src/jank/clojure/core.jank
@@ -80,7 +80,7 @@
 (def ^{:arglists '([o])}
   type
   (fn* type [o]
-    (cpp/jank.runtime.object_type_str (cpp/.-type (cpp/* o)))))
+    (cpp/jank.runtime.object_type_str (cpp/.get_type o))))
 
 ; Exceptions
 (def ^{:arglists '([msg map] [msg map cause])
@@ -120,7 +120,7 @@
        :doc "Returns true if x is nil, false otherwise."}
   nil?
   (fn* nil? [o]
-    (cpp/== (cpp/.-type (cpp/* o)) cpp/jank.runtime.object_type.nil)))
+    (cpp/== (cpp/.get_type o) cpp/jank.runtime.object_type.nil)))
 
 (def ^{:arglists '([lhs rhs])
        :doc "Tests if 2 arguments are the same object, meaning the same pointer address."}
@@ -2987,7 +2987,7 @@
                  (symbol? b) (-> bvec (conj b) (conj v))
                  (vector? b) (pvec bvec b v)
                  (map? b) (pmap bvec b v)
-                 :else (throw (str "Unsupported binding form: " b)))))
+                 :else (throw (str "Unsupported binding form: " b (type b))))))
         process-entry (fn process-entry [bvec b]
                         (pb bvec (first b) (second b)))]
     (if (every? symbol? (map first bents))

--- a/compiler+runtime/src/jank/clojure/core.jank
+++ b/compiler+runtime/src/jank/clojure/core.jank
@@ -2987,7 +2987,7 @@
                  (symbol? b) (-> bvec (conj b) (conj v))
                  (vector? b) (pvec bvec b v)
                  (map? b) (pmap bvec b v)
-                 :else (throw (str "Unsupported binding form: " b (type b))))))
+                 :else (throw (str "Unsupported binding form: " (pr-str b) " (" (type b) ")")))))
         process-entry (fn process-entry [bvec b]
                         (pb bvec (first b) (second b)))]
     (if (every? symbol? (map first bents))

--- a/compiler+runtime/test/cpp/jank/runtime/obj/big_integer.cpp
+++ b/compiler+runtime/test/cpp/jank/runtime/obj/big_integer.cpp
@@ -45,60 +45,60 @@ namespace jank::runtime::obj
 
       SUBCASE("big_integer vs big_integer")
       {
-        CHECK(bi1->equal(*bi2.erase()));
-        CHECK_FALSE(bi1->equal(*bi3.erase()));
-        CHECK_FALSE(bi1->equal(*bi_zero.erase()));
+        CHECK(bi1.equal(bi2));
+        CHECK_FALSE(bi1.equal(bi3));
+        CHECK_FALSE(bi1.equal(bi_zero));
       }
 
       SUBCASE("big_integer vs integer")
       {
-        big_integer const bi_i1(12345LL);
-        big_integer const bi_i3(-12345LL);
-        CHECK(bi_i1.equal(*i1.erase()));
-        CHECK(bi_i1.equal(*i2.erase()));
-        CHECK_FALSE(bi_i1.equal(*i3.erase()));
-        CHECK(bi_i3.equal(*i3.erase()));
-        CHECK_FALSE(bi_i3.equal(*i1.erase()));
+        auto const bi_i1(make_box<big_integer>(12345LL));
+        auto const bi_i3(make_box<big_integer>(-12345LL));
+        CHECK(bi_i1.equal(i1));
+        CHECK(bi_i1.equal(i2));
+        CHECK_FALSE(bi_i1.equal(i3));
+        CHECK(bi_i3.equal(i3));
+        CHECK_FALSE(bi_i3.equal(i1));
       }
 
       SUBCASE("big_integer vs real (epsilon comparison)")
       {
-        big_integer const bi_r1(12345LL);
-        big_integer const bi_r_large(nbi("123456789012345"));
+        auto const bi_r1(make_box<big_integer>(12345LL));
+        auto const bi_r_large(make_box(nbi("123456789012345")));
 
-        CHECK(bi_r1.equal(*r1.erase()));
-        CHECK_FALSE(bi_r1.equal(*r2.erase()));
-        CHECK(bi_r1.equal(*r3.erase()));
+        CHECK(bi_r1.equal(r1));
+        CHECK_FALSE(bi_r1.equal(r2));
+        CHECK(bi_r1.equal(r3));
 
 
-        CHECK(bi_r_large.equal(*r_large_exact.erase()));
-        CHECK(bi_r_large.equal(*r_large_approx.erase()));
+        CHECK(bi_r_large.equal(r_large_exact));
+        CHECK(bi_r_large.equal(r_large_approx));
 
         /* Numbers that cause overflow during conversion in `equal`. */
         /* Create a BI larger than double can represent. */
         native_big_integer const huge_val{ nbi("1") << 1024 };
-        big_integer const bi_huge_pos(huge_val);
-        big_integer const bi_huge_neg(-huge_val);
+        auto const bi_huge_pos(make_box<big_integer>(huge_val));
+        auto const bi_huge_neg(make_box<big_integer>(-huge_val));
         auto r_inf_pos{ make_box<real>(std::numeric_limits<f64>::infinity()) };
         auto r_inf_neg{ make_box<real>(-std::numeric_limits<f64>::infinity()) };
 
         /* Conversion works, but comparison should use epsilon logic which fails for inf. */
-        CHECK_FALSE(bi_huge_pos.equal(*r_inf_pos.erase()));
-        CHECK_FALSE(bi_huge_neg.equal(*r_inf_neg.erase()));
-        CHECK_FALSE(bi_huge_pos.equal(*r1.erase()));
+        CHECK_FALSE(bi_huge_pos.equal(r_inf_pos));
+        CHECK_FALSE(bi_huge_neg.equal(r_inf_neg));
+        CHECK_FALSE(bi_huge_pos.equal(r1));
       }
 
       SUBCASE("big_integer vs other type")
       {
-        CHECK_FALSE(bi1->equal(*ratio1.erase()));
+        CHECK_FALSE(bi1.equal(ratio1));
       }
     }
 
     TEST_CASE("String conversions")
     {
-      big_integer const bi_pos(nbi("1234567890987654321"));
-      big_integer const bi_neg(nbi("-9876543210123456789"));
-      big_integer const bi_zero(0);
+      auto const bi_pos(make_box<big_integer>(nbi("1234567890987654321")));
+      auto const bi_neg(make_box<big_integer>(nbi("-9876543210123456789")));
+      auto const bi_zero(make_box<big_integer>(0));
 
       SUBCASE("to_string()")
       {
@@ -182,40 +182,40 @@ namespace jank::runtime::obj
 
       SUBCASE("big_integer vs big_integer")
       {
-        CHECK_LT(bi_10->compare(*bi_20.erase()), 0);
-        CHECK_GT(bi_20->compare(*bi_10.erase()), 0);
-        CHECK_EQ(bi_10->compare(*make_box<big_integer>(10).erase()), 0);
-        CHECK_GT(bi_10->compare(*bi_10_neg.erase()), 0);
-        CHECK_LT(bi_10_neg->compare(*bi_10.erase()), 0);
-        CHECK_GT(bi_large->compare(*bi_20.erase()), 0);
+        CHECK_LT(bi_10.compare(bi_20), 0);
+        CHECK_GT(bi_20.compare(bi_10), 0);
+        CHECK_EQ(bi_10.compare(make_box<big_integer>(10)), 0);
+        CHECK_GT(bi_10.compare(bi_10_neg), 0);
+        CHECK_LT(bi_10_neg.compare(bi_10), 0);
+        CHECK_GT(bi_large.compare(bi_20), 0);
       }
 
       SUBCASE("big_integer vs integer")
       {
-        CHECK_LT(bi_10->compare(*i_15.erase()), 0);
-        CHECK_EQ(bi_10->compare(*i_10.erase()), 0);
-        CHECK_GT(bi_10->compare(*i_10_neg.erase()), 0);
-        CHECK_GT(bi_large->compare(*make_box<integer>(LLONG_MAX).erase()), 0);
+        CHECK_LT(bi_10.compare(i_15), 0);
+        CHECK_EQ(bi_10.compare(i_10), 0);
+        CHECK_GT(bi_10.compare(i_10_neg), 0);
+        CHECK_GT(bi_large.compare(make_box<integer>(LLONG_MAX)), 0);
       }
 
       SUBCASE("big_integer vs real")
       {
-        CHECK_LT(bi_10->compare(*r_10_5.erase()), 0);
-        CHECK_EQ(bi_10->compare(*r_10.erase()), 0);
-        CHECK_GT(bi_10->compare(*r_neg_10.erase()), 0);
-        CHECK_LT(bi_10_neg->compare(*r_neg_9_5.erase()), 0);
-        CHECK_GT(bi_large->compare(*make_box<real>(static_cast<f64>(LLONG_MAX)).erase()), 0);
+        CHECK_LT(bi_10.compare(r_10_5), 0);
+        CHECK_EQ(bi_10.compare(r_10), 0);
+        CHECK_GT(bi_10.compare(r_neg_10), 0);
+        CHECK_LT(bi_10_neg.compare(r_neg_9_5), 0);
+        CHECK_GT(bi_large.compare(make_box<real>(static_cast<f64>(LLONG_MAX))), 0);
       }
 
       SUBCASE("big_integer vs ratio")
       {
-        CHECK_GT(bi_10->compare(*ratio_half.erase()), 0);
-        CHECK_EQ(make_box<big_integer>(0)->compare(*ratio_half.erase()), -1);
+        CHECK_GT(bi_10.compare(ratio_half), 0);
+        CHECK_EQ(make_box<big_integer>(0).compare(ratio_half), -1);
       }
 
       SUBCASE("big_integer vs incompatible")
       {
-        CHECK_THROWS_AS(bi_10->compare(*bool_true.erase()), std::runtime_error);
+        CHECK_THROWS_AS(bi_10.compare(bool_true), std::runtime_error);
       }
     }
 

--- a/compiler+runtime/test/cpp/jank/runtime/obj/integer_range.cpp
+++ b/compiler+runtime/test/cpp/jank/runtime/obj/integer_range.cpp
@@ -11,13 +11,13 @@ namespace jank::runtime::obj
   {
     TEST_CASE("equal")
     {
-      CHECK(equal(integer_range::create(make_box(5)), integer_range::create(make_box(5))));
-      CHECK(equal(integer_range::create(make_box(1)), integer_range::create(make_box(1))));
-      CHECK(!equal(integer_range::create(make_box(6)), integer_range::create(make_box(5))));
-      CHECK(!equal(integer_range::create(make_box(5)), integer_range::create(make_box(6))));
-      CHECK(equal(integer_range::create(make_box(0)), integer_range::create(make_box(0))));
-      CHECK(!equal(integer_range::create(make_box(0)), integer_range::create(make_box(5))));
-      CHECK(!equal(integer_range::create(make_box(1)), integer_range::create(make_box(0))));
+      CHECK(equal(integer_range::create(5), integer_range::create(5)));
+      CHECK(equal(integer_range::create(1), integer_range::create(1)));
+      CHECK(!equal(integer_range::create(6), integer_range::create(5)));
+      CHECK(!equal(integer_range::create(5), integer_range::create(6)));
+      CHECK(equal(integer_range::create(0), integer_range::create(0)));
+      CHECK(!equal(integer_range::create(0), integer_range::create(5)));
+      CHECK(!equal(integer_range::create(1), integer_range::create(0)));
     }
   }
 }

--- a/compiler+runtime/test/cpp/jank/runtime/obj/persistent_array_map.cpp
+++ b/compiler+runtime/test/cpp/jank/runtime/obj/persistent_array_map.cpp
@@ -29,7 +29,7 @@ namespace jank::runtime::obj
 
       auto const pv{ v->assoc(make_box('9'), make_box('9')) };
 
-      CHECK(pv->type == object_type::persistent_hash_map);
+      CHECK(pv.get_type() == object_type::persistent_hash_map);
     }
 
     TEST_CASE("promotion to persistent_hash_map in conj")
@@ -53,7 +53,7 @@ namespace jank::runtime::obj
       auto const pv{ v->conj(
         make_box<persistent_vector>(std::in_place, make_box('9'), make_box('9'))) };
 
-      CHECK(pv->type == object_type::persistent_hash_map);
+      CHECK(pv.get_type() == object_type::persistent_hash_map);
     }
   }
 }

--- a/compiler+runtime/test/cpp/jank/runtime/obj/ratio.cpp
+++ b/compiler+runtime/test/cpp/jank/runtime/obj/ratio.cpp
@@ -56,7 +56,7 @@ namespace jank::runtime
       SUBCASE("Simplify to integer")
       {
         auto const ratio_ptr{ obj::ratio::create(4, 2) };
-        CHECK_EQ(ratio_ptr->type, object_type::integer);
+        CHECK_EQ(ratio_ptr.get_type(), object_type::integer);
         CHECK_EQ(expect_object<obj::integer>(ratio_ptr)->data, 2);
       }
 
@@ -147,12 +147,12 @@ namespace jank::runtime
       SUBCASE("Addition with native integer")
       {
         i64 const i{ 2ll };
-        auto const result{ *(ratio + i) };
-        auto const result2{ *(i + ratio) };
-        CHECK_EQ(result.data.numerator, 11);
-        CHECK_EQ(result.data.denominator, 4);
-        CHECK_EQ(result2.data.numerator, 11);
-        CHECK_EQ(result2.data.denominator, 4);
+        auto const result{ (ratio + i) };
+        auto const result2{ (i + ratio) };
+        CHECK_EQ(result.numerator, 11);
+        CHECK_EQ(result.denominator, 4);
+        CHECK_EQ(result2.numerator, 11);
+        CHECK_EQ(result2.denominator, 4);
       }
       SUBCASE("Addition with native real")
       {
@@ -165,13 +165,13 @@ namespace jank::runtime
 
       SUBCASE("Subtraction with boxed int")
       {
-        auto const i{ make_box(1) };
+        auto const i{ make_box<obj::integer>(1) };
         auto const result{ ratio - i };
         auto const result2{ i - ratio };
-        CHECK_EQ(result->data.numerator, -1);
-        CHECK_EQ(result->data.denominator, 4);
-        CHECK_EQ(result2->data.numerator, 1);
-        CHECK_EQ(result2->data.denominator, 4);
+        CHECK_EQ(result.numerator, -1);
+        CHECK_EQ(result.denominator, 4);
+        CHECK_EQ(result2.numerator, 1);
+        CHECK_EQ(result2.denominator, 4);
       }
 
       SUBCASE("Subtraction with boxed real")
@@ -185,7 +185,7 @@ namespace jank::runtime
 
       SUBCASE("Multiplication with boxed int")
       {
-        auto const i{ make_box(3) };
+        auto const i{ make_box<obj::integer>(3) };
         auto const result{ *expect_object<obj::ratio>(ratio * i) };
         auto const result2{ *expect_object<obj::ratio>(i * ratio) };
         CHECK_EQ(result.data.numerator, 9);
@@ -225,7 +225,7 @@ namespace jank::runtime
 
       SUBCASE("Comparison with boxed integer")
       {
-        auto const i{ make_box(1ll) };
+        auto const i{ make_box<obj::integer>(1ll) };
         CHECK_LT(ratio, i);
         CHECK_NE(ratio, i);
         CHECK_NE(i, ratio);
@@ -255,14 +255,14 @@ namespace jank::runtime
 
       SUBCASE("Complex arithmetic chain")
       {
-        auto const result{ (ratio + i)->data - r };
+        auto const result{ (ratio + i) - r };
         CHECK_EQ(result, doctest::Approx(3.375));
       }
 
       SUBCASE("Mixed comparison")
       {
         auto const real_ptr{ make_box(1.0) };
-        auto const int_ptr{ make_box(1ll) };
+        auto const int_ptr{ make_box<obj::integer>(1ll) };
 
         CHECK_LT(ratio, real_ptr);
         CHECK_LT(ratio, int_ptr);

--- a/compiler+runtime/test/cpp/jank/runtime/obj/transient_array_map.cpp
+++ b/compiler+runtime/test/cpp/jank/runtime/obj/transient_array_map.cpp
@@ -29,7 +29,7 @@ namespace jank::runtime::obj
 
       auto const pv{ v->assoc_in_place(make_box('9'), make_box('9')) };
 
-      CHECK(pv->type == object_type::transient_hash_map);
+      CHECK(pv.get_type() == object_type::transient_hash_map);
     }
 
     TEST_CASE("promotion to transient_hash_map in conj_in_place")
@@ -53,7 +53,7 @@ namespace jank::runtime::obj
       auto const pv{ v->conj_in_place(
         make_box<persistent_vector>(std::in_place, make_box('9'), make_box('9'))) };
 
-      CHECK(pv->type == object_type::transient_hash_map);
+      CHECK(pv.get_type() == object_type::transient_hash_map);
     }
   }
 }

--- a/compiler+runtime/test/jank/cpp/auto-box/pass-native-type-to-typed-object.jank
+++ b/compiler+runtime/test/jank/cpp/auto-box/pass-native-type-to-typed-object.jank
@@ -1,8 +1,8 @@
 (cpp/raw "namespace jank::cpp::auto_box::pass_native_type_to_typed_object
           {
-            runtime::obj::integer_ref foo(runtime::obj::integer_ref const o)
+            runtime::obj::real_ref foo(runtime::obj::real_ref const o)
             { return o; }
           }")
-(let* [f (cpp/jank.cpp.auto_box.pass_native_type_to_typed_object.foo (cpp/int 555))]
-  (if (= 555 f)
+(let* [f (cpp/jank.cpp.auto_box.pass_native_type_to_typed_object.foo (cpp/float 555.0))]
+  (if (= 555.0 f)
     :success))

--- a/compiler+runtime/test/jank/cpp/if/pass-different-typed-objects.jank
+++ b/compiler+runtime/test/jank/cpp/if/pass-different-typed-objects.jank
@@ -1,12 +1,12 @@
 (cpp/raw "namespace jank::cpp::if_::pass_different_typed_objects
           {
-            runtime::obj::integer_ref foo()
-            { return runtime::make_box(2222); }
+            runtime::obj::real_ref foo()
+            { return runtime::make_box(2222.0); }
             runtime::obj::persistent_string_ref bar()
             { return runtime::make_box(\"meow\"); }
           }")
 (let* [r (if true
            (cpp/jank.cpp.if_.pass_different_typed_objects.foo)
            (cpp/jank.cpp.if_.pass_different_typed_objects.bar))]
-  (if (= r 2222)
+  (if (= r 2222.0)
     :success))

--- a/compiler+runtime/test/jank/cpp/if/pass-object-ref-condition.jank
+++ b/compiler+runtime/test/jank/cpp/if/pass-object-ref-condition.jank
@@ -1,7 +1,7 @@
 (cpp/raw "namespace jank::cpp::if_::pass_object_ref_condition
          {
            runtime::object_ref is_nil(runtime::object_ref const o)
-           { return runtime::make_box(o->type == runtime::object_type::nil); }
+           { return runtime::make_box(o.get_type() == runtime::object_type::nil); }
          }")
 (let* [f (fn* [o]
            (if (cpp/jank.cpp.if_.pass_object_ref_condition.is_nil o)


### PR DESCRIPTION
This PR adds support for tagging pointers to store inline integers. This allows us to avoid dynamic allocations for basically all integers, but it requires us to add a lot more robust behavior around how pointers are handled.