### PR TITLE
Update `:inline` evaluations to happen in their defining namespace

### DIFF
--- a/compiler+runtime/src/cpp/jank/analyze/processor.cpp
+++ b/compiler+runtime/src/cpp/jank/analyze/processor.cpp
@@ -3286,9 +3286,12 @@ namespace jank::analyze
             runtime::get(var_deref->var->get_meta(),
                          __rt_ctx->intern_keyword("", "inline", true).expect_ok()));
           /* TODO: Once we're evaluating meta, we can remove this eval. */
-          context::binding_scope const _{ runtime::obj::persistent_hash_map::create_unique(
-            std::make_pair(__rt_ctx->current_ns_var, var_deref->var->n)) };
-          auto const actual_fn{ __rt_ctx->eval(inline_fn) };
+          object_ref actual_fn;
+          {
+            context::binding_scope const _{ runtime::obj::persistent_hash_map::create_unique(
+              std::make_pair(__rt_ctx->current_ns_var, var_deref->var->n)) };
+            actual_fn = __rt_ctx->eval(inline_fn);
+          }
           auto const expanded{ apply_to(actual_fn, o->next()) };
           return analyze(expanded, current_frame, position, fn_ctx, needs_box);
         }

--- a/compiler+runtime/src/cpp/jank/analyze/processor.cpp
+++ b/compiler+runtime/src/cpp/jank/analyze/processor.cpp
@@ -3286,6 +3286,8 @@ namespace jank::analyze
             runtime::get(var_deref->var->get_meta(),
                          __rt_ctx->intern_keyword("", "inline", true).expect_ok()));
           /* TODO: Once we're evaluating meta, we can remove this eval. */
+          context::binding_scope const _{ runtime::obj::persistent_hash_map::create_unique(
+            std::make_pair(__rt_ctx->current_ns_var, var_deref->var->n)) };
           auto const actual_fn{ __rt_ctx->eval(inline_fn) };
           auto const expanded{ apply_to(actual_fn, o->next()) };
           return analyze(expanded, current_frame, position, fn_ctx, needs_box);


### PR DESCRIPTION
After the recent IR changes, which contained some `:inline` optimizations, code I had in Portal stopped working. It was of the following form:

```clojure
(ns foo (:refer-clojure :exclude [list]))

(doseq [_ []])
```

and I was getting the following error:

```
─ analyze/unresolved-symbol ────────────────────────────────────────────────────────────────────────
error: Unable to resolve symbol 'list'.                                                             
                                                                                                    
─────┬──────────────────────────────────────────────────────────────────────────────────────────────                                                                                                                                                                                                                  
     │ src/jank/clojure/core.jank                                                                                                                                                                                                                                                                                     
─────┼──────────────────────────────────────────────────────────────────────────────────────────────                                                                                                                                                                                                                  
  1  │ ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;                                                                                                                                                                                                                               
     │                                                                                                                                                                                                                                                                                                ^^^^ Found here.
     │                                                                                                                                                                                                                                                                                     ^ Expanded from this macro.
─────┴────────────────────────────────────────────────────────────────────────────────────────────── 
```

The issue turned out to be that we were evaluating the `:inline` lambdas in the target ns, instead of `clojure.core`. This fix ensures those lambda get evaluated in their defining ns. When we move to evaluating metadata, the lambda's that get created will likewise also be bound to `clojure.core`.

> [!NOTE]
> I did use a LLM (Claude Code) to help me narrow down why I was having the issue in jank, but I implemented the solution.

My intension is to accomplish the following, and it does appear to work, but I'm not too familiar with doing it on the cpp side:

```clojure
(binding [*ns* (-> v meta :ns)]
  (eval (-> v meta :inline)))
```