### PR TITLE
Implement `promise`

### DIFF
--- a/compiler+runtime/CMakeLists.txt
+++ b/compiler+runtime/CMakeLists.txt
@@ -619,6 +619,7 @@ add_library(
   src/cpp/jank/runtime/obj/volatile.cpp
   src/cpp/jank/runtime/obj/delay.cpp
   src/cpp/jank/runtime/obj/future.cpp
+  src/cpp/jank/runtime/obj/promise.cpp
   src/cpp/jank/runtime/obj/reduced.cpp
   src/cpp/jank/runtime/obj/reader_conditional.cpp
   src/cpp/jank/runtime/behavior/metadatable.cpp

--- a/compiler+runtime/include/cpp/jank/runtime/core.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/core.hpp
@@ -15,6 +15,7 @@ namespace jank::runtime
   namespace obj
   {
     using native_vector_sequence_ref = oref<struct native_vector_sequence>;
+    using promise_ref = oref<struct promise>;
   }
 
   jtl::immutable_string type(object_ref const o);
@@ -123,7 +124,7 @@ namespace jank::runtime
   void cancel_future(object_ref const future);
   bool is_future_cancelled(object_ref const future);
 
-  object_ref promise();
+  obj::promise_ref promise();
 
   object_ref read_string(object_ref const form_string, object_ref const opts);
   object_ref read_file(object_ref const file_path, object_ref const opts);

--- a/compiler+runtime/include/cpp/jank/runtime/core.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/core.hpp
@@ -123,6 +123,8 @@ namespace jank::runtime
   void cancel_future(object_ref const future);
   bool is_future_cancelled(object_ref const future);
 
+  object_ref promise();
+
   object_ref read_string(object_ref const form_string, object_ref const opts);
   object_ref read_file(object_ref const file_path, object_ref const opts);
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/promise.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/promise.hpp
@@ -35,11 +35,16 @@ namespace jank::runtime::obj
 
     struct mutable_state
     {
+      /*** XXX: Val is immutable after initialization. ***/
       object_ref val;
       promise_status status{ promise_status::pending };
     };
 
+    /*** XXX: Everything here is thread-safe. ***/
+
     mutable folly::Synchronized<mutable_state> state;
+    /* sync.wait() is thread safe for multiple concurrent blocking derefs
+     * sync.notify_all() is also thread safe, but will only actually be called during a state.wlock() */
     mutable std::condition_variable_any sync;
   };
 }

--- a/compiler+runtime/include/cpp/jank/runtime/obj/promise.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/obj/promise.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <condition_variable>
+
+#include <folly/Synchronized.h>
+
+#include <jank/runtime/object.hpp>
+
+namespace jank::runtime::obj
+{
+  using promise_ref = oref<struct promise>;
+
+  enum class promise_status : u8
+  {
+    pending,
+    ready
+  };
+
+  struct promise : object
+  {
+    static constexpr object_type obj_type{ object_type::promise };
+    static constexpr object_behavior obj_behaviors{ object_behavior::call };
+    static constexpr bool pointer_free{ false };
+
+    promise();
+
+    /* behavior::derefable */
+    object_ref deref();
+
+    /* behavior::realizable */
+    bool is_realized() const;
+
+    /* behavior::callable */
+    object_ref call(object_ref const) const override;
+
+    struct mutable_state
+    {
+      object_ref val;
+      promise_status status{ promise_status::pending };
+    };
+
+    mutable folly::Synchronized<mutable_state> state;
+    mutable std::condition_variable_any sync;
+  };
+}

--- a/compiler+runtime/include/cpp/jank/runtime/object.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/object.hpp
@@ -78,6 +78,7 @@ namespace jank::runtime
     reduced,
     delay,
     future,
+    promise,
     ns,
 
     var,
@@ -223,6 +224,8 @@ namespace jank::runtime
         return "delay";
       case object_type::future:
         return "future";
+      case object_type::promise:
+        return "promise";
       case object_type::ns:
         return "ns";
 

--- a/compiler+runtime/include/cpp/jank/runtime/visit.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/visit.hpp
@@ -54,6 +54,7 @@
 #include <jank/runtime/obj/volatile.hpp>
 #include <jank/runtime/obj/delay.hpp>
 #include <jank/runtime/obj/future.hpp>
+#include <jank/runtime/obj/promise.hpp>
 #include <jank/runtime/obj/reduced.hpp>
 #include <jank/runtime/obj/tagged_literal.hpp>
 #include <jank/runtime/obj/re_pattern.hpp>
@@ -207,6 +208,8 @@ namespace jank::runtime
         return fn(expect_object<obj::delay>(erased), std::forward<Args>(args)...);
       case object_type::future:
         return fn(expect_object<obj::future>(erased), std::forward<Args>(args)...);
+      case object_type::promise:
+        return fn(expect_object<obj::promise>(erased), std::forward<Args>(args)...);
       case object_type::ns:
         return fn(expect_object<ns>(erased), std::forward<Args>(args)...);
       case object_type::var:

--- a/compiler+runtime/src/cpp/jank/runtime/core.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core.cpp
@@ -879,6 +879,11 @@ namespace jank::runtime
 #endif
   }
 
+  object_ref promise()
+  {
+    return make_box<obj::promise>();
+  }
+
   object_ref read_string(object_ref const form_string, object_ref const opts)
   {
     if(form_string.get_type() != object_type::persistent_string)

--- a/compiler+runtime/src/cpp/jank/runtime/core.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core.cpp
@@ -879,7 +879,7 @@ namespace jank::runtime
 #endif
   }
 
-  object_ref promise()
+  obj::promise_ref promise()
   {
     return make_box<obj::promise>();
   }

--- a/compiler+runtime/src/cpp/jank/runtime/obj/promise.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/obj/promise.cpp
@@ -1,0 +1,36 @@
+#include <jank/runtime/obj/promise.hpp>
+
+namespace jank::runtime::obj
+{
+  promise::promise()
+    : object{ obj_type, obj_behaviors }
+  {
+  }
+
+  object_ref promise::deref()
+  {
+    auto locked_state{ state.wlock() };
+    sync.wait(locked_state.as_lock(),
+              [&] { return locked_state->status == promise_status::ready; });
+    return locked_state->val;
+  }
+
+  bool promise::is_realized() const
+  {
+    auto const locked_state{ state.rlock() };
+    return locked_state->status == promise_status::ready;
+  }
+
+  object_ref promise::call(object_ref const o) const
+  {
+    auto const locked_state{ state.wlock() };
+    if(locked_state->status == promise_status::pending)
+    {
+      locked_state->val = o;
+      locked_state->status = promise_status::ready;
+      sync.notify_all();
+    }
+    return this;
+  }
+
+}

--- a/compiler+runtime/src/jank/clojure/core.jank
+++ b/compiler+runtime/src/jank/clojure/core.jank
@@ -7156,28 +7156,7 @@ fails, attempts to require sym's namespace and retries."
   subsequent derefs will return the same delivered value without
   blocking. See also - realized?."
   []
-  ;; (let [d (java.util.concurrent.CountDownLatch. 1)
-  ;;       v (atom d)]
-  ;;   (reify
-  ;;    clojure.lang.IDeref
-  ;;      (deref [_] (.await d) @v)
-  ;;    clojure.lang.IBlockingDeref
-  ;;      (deref
-  ;;       [_ timeout-ms timeout-val]
-  ;;       (if (.await d timeout-ms java.util.concurrent.TimeUnit/MILLISECONDS)
-  ;;         @v
-  ;;         timeout-val))
-  ;;    clojure.lang.IPending
-  ;;     (isRealized [this]
-  ;;      (zero? (.getCount d)))
-  ;;    clojure.lang.IFn
-  ;;    (invoke
-  ;;     [this x]
-  ;;     (when (and (pos? (.getCount d))
-  ;;                (compare-and-set! v d x))
-  ;;       (.countDown d)
-  ;;       this))))
-  (throw "TODO: port promise"))
+  (cpp/jank.runtime.promise))
 
 (defn deliver
   "Delivers the supplied value to the promise, releasing any pending


### PR DESCRIPTION
I used the `future` struct as a starting place for `promise`, then added a `condition_variable` to implement sync similar to `native_array_blocking_queue`.

I explored using `std::promise` and `std::future` but ran into two issues:
- We would have to always catch [`std::proimise::set_value`](https://en.cppreference.com/cpp/thread/promise/set_value) since setting it more than once throws an exception
- I got a strange linking error that I couldn't get past



```
[408/435] Linking CXX executable jank-phase-1
FAILED: [code=1] jank-phase-1 
: && /home/chris/repos/jank/compiler+runtime/build/llvm-install/usr/local/bin/clang++ -fPIC -fno-semantic-interposition -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wno-pass-failed -Wmisleading-indentation -Wctad-maybe-unsupported -fdiagnostics-color -g -Wl,--export-dynamic -rdynamic  -L /home/chris/repos/jank/compiler+runtime/build -Xlinker --dependency-file=CMakeFiles/jank_exe_phase_1.dir/link.d CMakeFiles/jank_exe_phase_1.dir/src/cpp/main.cpp.o CMakeFiles/jank_exe_phase_1.dir/src/cpp/jank/environment/check_health.cpp.o -o jank-phase-1 -L/home/chris/repos/jank/compiler+runtime/build/llvm-install/usr/local/lib -Wl,-rpath,/home/chris/repos/jank/compiler+runtime/build/llvm-install/usr/local/lib  -Wl,--whole-archive  libjank-standalone-phase-1.a  -Wl,--no-whole-archive  -lz  llvm-install/usr/local/lib/libclang-cpp.so.22.1-rc1  /usr/lib/libcrypto.so  llvm-install/usr/local/lib/libLLVM.so.22.1-rc1 && :
/usr/bin/ld: libjank-standalone-phase-1.a(promise.cpp.o): in function `std::once_flag::_Prepare_execution::_Prepare_execution<std::call_once<void (std::__future_base::_State_baseV2::*)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*>(std::once_flag&, void (std::__future_base::_State_baseV2::*&&)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*&&, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*&&, bool*&&)::{lambda()#1}>(void (std::__future_base::_State_baseV2::*&)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*))':
/usr/include/c++/15.2.1/mutex:845:(.text._ZNSt9once_flag18_Prepare_executionC2IZSt9call_onceIMNSt13__future_base13_State_baseV2EFvPSt8functionIFSt10unique_ptrINS3_12_Result_baseENS7_8_DeleterEEvEEPbEJPS4_SC_SD_EEvRS_OT_DpOT0_EUlvE_EERSI_[_ZNSt9once_flag18_Prepare_executionC2IZSt9call_onceIMNSt13__future_base13_State_baseV2EFvPSt8functionIFSt10unique_ptrINS3_12_Result_baseENS7_8_DeleterEEvEEPbEJPS4_SC_SD_EEvRS_OT_DpOT0_EUlvE_EERSI_]+0x1b): undefined reference to `__emutls_v._ZSt15__once_callable'
/usr/bin/ld: /usr/include/c++/15.2.1/mutex:847:(.text._ZNSt9once_flag18_Prepare_executionC2IZSt9call_onceIMNSt13__future_base13_State_baseV2EFvPSt8functionIFSt10unique_ptrINS3_12_Result_baseENS7_8_DeleterEEvEEPbEJPS4_SC_SD_EEvRS_OT_DpOT0_EUlvE_EERSI_[_ZNSt9once_flag18_Prepare_executionC2IZSt9call_onceIMNSt13__future_base13_State_baseV2EFvPSt8functionIFSt10unique_ptrINS3_12_Result_baseENS7_8_DeleterEEvEEPbEJPS4_SC_SD_EEvRS_OT_DpOT0_EUlvE_EERSI_]+0x3b): undefined reference to `__emutls_v._ZSt11__once_call'
/usr/bin/ld: libjank-standalone-phase-1.a(promise.cpp.o): in function `std::once_flag::_Prepare_execution::~_Prepare_execution()':
/usr/include/c++/15.2.1/mutex:853:(.text._ZNSt9once_flag18_Prepare_executionD2Ev[_ZNSt9once_flag18_Prepare_executionD2Ev]+0xf): undefined reference to `__emutls_v._ZSt15__once_callable'
/usr/bin/ld: /usr/include/c++/15.2.1/mutex:854:(.text._ZNSt9once_flag18_Prepare_executionD2Ev[_ZNSt9once_flag18_Prepare_executionD2Ev]+0x22): undefined reference to `__emutls_v._ZSt11__once_call'
/usr/bin/ld: libjank-standalone-phase-1.a(promise.cpp.o): in function `std::once_flag::_Prepare_execution::_Prepare_execution<std::call_once<void (std::__future_base::_State_baseV2::*)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*>(std::once_flag&, void (std::__future_base::_State_baseV2::*&&)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*&&, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*&&, bool*&&)::{lambda()#1}>(void (std::__future_base::_State_baseV2::*&)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*))::{lambda()#1}::operator()() const':
/usr/include/c++/15.2.1/mutex:847:(.text._ZZNSt9once_flag18_Prepare_executionC1IZSt9call_onceIMNSt13__future_base13_State_baseV2EFvPSt8functionIFSt10unique_ptrINS3_12_Result_baseENS7_8_DeleterEEvEEPbEJPS4_SC_SD_EEvRS_OT_DpOT0_EUlvE_EERSI_ENKUlvE_clEv[_ZZNSt9once_flag18_Prepare_executionC1IZSt9call_onceIMNSt13__future_base13_State_baseV2EFvPSt8functionIFSt10unique_ptrINS3_12_Result_baseENS7_8_DeleterEEvEEPbEJPS4_SC_SD_EEvRS_OT_DpOT0_EUlvE_EERSI_ENKUlvE_clEv]+0xf): undefined reference to `__emutls_v._ZSt15__once_callable'
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```